### PR TITLE
feat: Refactor reboot code to support crash mode

### DIFF
--- a/include/aplus/hal.h
+++ b/include/aplus/hal.h
@@ -52,6 +52,7 @@
     #define ARCH_REBOOT_SUSPEND  1
     #define ARCH_REBOOT_POWEROFF 2
     #define ARCH_REBOOT_HALT     3
+    #define ARCH_REBOOT_CRASH    4
 
 
     #define ARCH_VMM_AREA_HEAP   1

--- a/libk/kpanicf.c
+++ b/libk/kpanicf.c
@@ -72,8 +72,5 @@ __noreturn __nosanitize("undefined") void kpanicf(const char* fmt, ...) {
     arch_debug_putc('m');
 
 
-    for (;;) {
-        __cpu_pause();
-        __cpu_halt();
-    }
+    arch_reboot(ARCH_REBOOT_CRASH);
 }


### PR DESCRIPTION
The code changes in `arch/x86-family/reboot.c` modify the reboot code to support a new `ARCH_REBOOT_CRASH` mode. This mode allows the system to perform a crash reboot by sending specific commands to the QEMU and VirtualBox virtual machines. Additionally, the code in `libk/kpanicf.c` has been updated to use the new `arch_reboot()` function with the `ARCH_REBOOT_CRASH` mode. This change enhances the system's reboot capabilities and provides a mechanism for triggering a crash reboot in virtual machine environments.