### PR TITLE
fix: virtio queues

### DIFF
--- a/arch/x86-family/cpu/ioapic.c
+++ b/arch/x86-family/cpu/ioapic.c
@@ -53,7 +53,7 @@ static inline uint32_t ioapic_read(uintptr_t address, const uint32_t offset) {
 }
 
 
-void ioapic_map_irq(irq_t source, irq_t irq, cpuid_t cpu) {
+void ioapic_map_irq(irq_t source, irq_t irq, cpuid_t cpu, uint64_t flags) {
 
     for (size_t i = 0; i < X86_IOAPIC_MAX; i++) {
 
@@ -67,6 +67,7 @@ void ioapic_map_irq(irq_t source, irq_t irq, cpuid_t cpu) {
                 uint64_t d = 0;
                 d |= (0x20 + irq) & 0xFF;
                 d |= (uint64_t)cpu << 56;
+                d |= (flags & X86_IOAPIC_REDTTBL_FLAG_MASK);
 
                 ioapic_write(ioapic[i].address, X86_IOAPIC_IOAPICREDTBL(source), d & 0xFFFFFFFF);
                 ioapic_write(ioapic[i].address, X86_IOAPIC_IOAPICREDTBL(source) + 1, (d >> 32) & 0xFFFFFFFF);

--- a/arch/x86-family/fpu.c
+++ b/arch/x86-family/fpu.c
@@ -326,7 +326,7 @@ size_t fpu_size(void) {
 
 void* fpu_new_state(void) {
 
-    void* p = (void*)((uintptr_t)kcalloc(fpu_size() + FPU_PAD_SIZE, 1, GFP_KERNEL) + FPU_PAD_SIZE);
+    void* p = (void*)((uintptr_t)kcalloc(1, fpu_size() + FPU_PAD_SIZE, GFP_KERNEL) + FPU_PAD_SIZE);
 
     DEBUG_ASSERT((uintptr_t)p);
     DEBUG_ASSERT(((uintptr_t)p & 63) == 0);

--- a/arch/x86-family/intr.c
+++ b/arch/x86-family/intr.c
@@ -70,7 +70,6 @@ void* x86_exception_handler(interrupt_frame_t* frame) {
 
 
     if (likely(frame->intno >= 0x20)) {
-
         current_cpu->frame = frame;
     }
 
@@ -96,10 +95,9 @@ void* x86_exception_handler(interrupt_frame_t* frame) {
 
         case 0x21 ... 0xFD:
 
-            if (likely(bootstrap_irq[frame->intno - 0x20].handler))
+            if (likely(bootstrap_irq[frame->intno - 0x20].handler)) {
                 bootstrap_irq[frame->intno - 0x20].handler(frame, frame->intno - 0x20);
-
-            else {
+            } else {
 #if DEBUG_LEVEL_WARN
                 kprintf("x86-intr: WARN! unhandled IRQ #%ld caught, ignoring\n", frame->intno - 0x20);
 #endif
@@ -195,11 +193,10 @@ long arch_intr_disable(void) {
 
 
 
-void arch_intr_map_irq(irq_t irq, void (*handler)(void*, irq_t)) {
+void arch_intr_map_irq(irq_t irq, void (*handler)(void*, irq_t), int type) {
 
     DEBUG_ASSERT(irq < (0xFF - 0x20));
     DEBUG_ASSERT(handler);
-
 
     if (unlikely(bootstrap_irq[irq].handler && bootstrap_irq[irq].handler != handler))
         kpanicf("x86-intr: PANIC! can not map irq(%d), already owned by %p\n", irq, bootstrap_irq[irq].handler);
@@ -207,17 +204,28 @@ void arch_intr_map_irq(irq_t irq, void (*handler)(void*, irq_t)) {
 
     bootstrap_irq[irq].handler = handler;
 
-    ioapic_map_irq(irq, irq, current_cpu->id);
+    switch(type) {
+        case ARCH_INTR_TYPE_DEFAULT:
+            ioapic_map_irq(irq, irq, current_cpu->id, X86_IOAPIC_REDTTBL_FLAG_TRIGGER_MODE_EDGE | X86_IOAPIC_REDTTBL_FLAG_POLARITY_ACTIVE_HIGH);
+            break;
 
+        case ARCH_INTR_TYPE_PCI:
+            ioapic_map_irq(irq, irq, current_cpu->id, X86_IOAPIC_REDTTBL_FLAG_TRIGGER_MODE_LEVEL | X86_IOAPIC_REDTTBL_FLAG_POLARITY_ACTIVE_LOW);
+            break;
 
+        case ARCH_INTR_TYPE_MSI:
+            break;
+
+        default:
+            kpanicf("x86-intr: PANIC! unknown interrupt type %d for irq %d\n", type, irq);
+    }
 
 #if DEBUG_LEVEL_TRACE
     kprintf("x86-intr: map irq(%d) at %p\n", irq, handler);
 #endif
 }
 
-
-void arch_intr_unmap_irq(irq_t irq) {
+void arch_intr_unmap_irq(irq_t irq, int type) {
 
     DEBUG_ASSERT(irq < (0xFF - 0x20));
     DEBUG_ASSERT(bootstrap_irq[irq].handler != NULL);
@@ -225,7 +233,18 @@ void arch_intr_unmap_irq(irq_t irq) {
 
     bootstrap_irq[irq].handler = NULL;
 
-    ioapic_unmap_irq(irq);
+    switch(type) {
+        case ARCH_INTR_TYPE_DEFAULT:
+        case ARCH_INTR_TYPE_PCI:
+            ioapic_unmap_irq(irq);
+            break;
+
+        case ARCH_INTR_TYPE_MSI:
+            break;
+
+        default:
+            kpanicf("x86-intr: PANIC! unknown interrupt type %d for irq %d\n", type, irq);
+    }
 
 
 #if DEBUG_LEVEL_TRACE
@@ -234,35 +253,3 @@ void arch_intr_unmap_irq(irq_t irq) {
 }
 
 
-void arch_intr_map_irq_without_ioapic(irq_t irq, void (*handler)(void*, irq_t)) {
-
-    DEBUG_ASSERT(irq < (0xFF - 0x20));
-    DEBUG_ASSERT(handler);
-
-
-    if (unlikely(bootstrap_irq[irq].handler && bootstrap_irq[irq].handler != handler))
-        kpanicf("x86-intr: PANIC! can not map irq(%d), already owned by %p\n", irq, bootstrap_irq[irq].handler);
-
-
-    bootstrap_irq[irq].handler = handler;
-
-
-#if DEBUG_LEVEL_TRACE
-    kprintf("x86-intr: map irq(%d) at %p without I/O APIC\n", irq, handler);
-#endif
-}
-
-
-void arch_intr_unmap_irq_without_ioapic(irq_t irq) {
-
-    DEBUG_ASSERT(irq < (0xFF - 0x20));
-    DEBUG_ASSERT(bootstrap_irq[irq].handler != NULL);
-
-
-    bootstrap_irq[irq].handler = NULL;
-
-
-#if DEBUG_LEVEL_TRACE
-    kprintf("x86-intr: unmap irq(%d) without I/O APIC\n", irq);
-#endif
-}

--- a/arch/x86-family/task.c
+++ b/arch/x86-family/task.c
@@ -267,7 +267,7 @@ task_t* arch_task_get_empty_thread(size_t stacksize) {
 
 
 
-#define _(size, offset) (void*)((uintptr_t)kcalloc(size, 1, GFP_KERNEL) + offset)
+#define _(size, offset) (void*)((uintptr_t)kcalloc(1, size, GFP_KERNEL) + offset)
 
 
     task->frame  = _(sizeof(interrupt_frame_t), 0);
@@ -328,7 +328,7 @@ pid_t arch_task_spawn_init() {
 
 
 
-#define _(size, offset) (void*)((uintptr_t)kcalloc(size, 1, GFP_KERNEL) + offset)
+#define _(size, offset) (void*)((uintptr_t)kcalloc(1, size, GFP_KERNEL) + offset)
 
     task->frame  = _(sizeof(interrupt_frame_t), 0);
     task->sstack = _(sizeof(sigcontext_frame_t) + fpu_size(), 0);

--- a/drivers/block/ram/main.c
+++ b/drivers/block/ram/main.c
@@ -157,7 +157,7 @@ void init(const char* args) {
 
 
 
-        device_t* d = (device_t*)kcalloc(sizeof(device_t), 1, GFP_KERNEL);
+        device_t* d = (device_t*)kcalloc(1, sizeof(device_t), GFP_KERNEL);
 
         strncpy(d->name, "ram0", DEVICE_MAXNAMELEN);
         strncpy(d->description, "RAM disk device", DEVICE_MAXDESCLEN);

--- a/drivers/dev/block/part.c
+++ b/drivers/dev/block/part.c
@@ -79,7 +79,7 @@ static void device_mkpart(device_t* device, inode_t* inode, void (*mkdev)(device
     DEBUG_ASSERT(index < 1000);
 
 
-    device_t* d = (device_t*)kcalloc(sizeof(device_t), 1, GFP_KERNEL);
+    device_t* d = (device_t*)kcalloc(1, sizeof(device_t), GFP_KERNEL);
 
 
     d->type = DEVICE_TYPE_BLOCK;

--- a/drivers/dev/pci/pci_dev.c
+++ b/drivers/dev/pci/pci_dev.c
@@ -76,6 +76,7 @@ uint16_t pci_dev_unregister(pcidev_t device) {
                 continue;
 
             pci_devices[i].device  = 0;
+            pci_devices[i].vector  = 0;
             pci_devices[i].handler = NULL;
             pci_devices[i].data    = NULL;
 

--- a/drivers/dev/pci/pci_dev.c
+++ b/drivers/dev/pci/pci_dev.c
@@ -1,0 +1,106 @@
+/*
+ * Author:
+ *      Antonino Natale <antonio.natale97@hotmail.com>
+ *
+ * Copyright (c) 2013-2019 Antonino Natale
+ *
+ *
+ * This file is part of aplus.
+ *
+ * aplus is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * aplus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with aplus.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdatomic.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <aplus.h>
+#include <aplus/debug.h>
+#include <aplus/endian.h>
+#include <aplus/errno.h>
+#include <aplus/hal.h>
+#include <aplus/module.h>
+#include <aplus/vfs.h>
+
+#include <dev/interface.h>
+#include <dev/pci.h>
+
+static struct {
+    uint16_t vector;
+    pcidev_t device;
+    pci_irq_handler_t handler;
+    pci_irq_data_t data;
+} pci_devices[PCI_DEVICES_MAX] = {0};
+
+static spinlock_t pci_dev_lock = SPINLOCK_INIT_WITH_FLAGS(SPINLOCK_FLAGS_CPU_OWNER);
+
+uint16_t pci_dev_register(pcidev_t device, pci_irq_handler_t handler, pci_irq_data_t data, uint16_t vector) {
+
+    scoped_lock(&pci_dev_lock) {
+
+        for (size_t i = 0; i < PCI_DEVICES_MAX; i++) {
+
+            if (pci_devices[i].device)
+                continue;
+
+            pci_devices[i].vector  = vector;
+            pci_devices[i].device  = device;
+            pci_devices[i].handler = handler;
+            pci_devices[i].data    = data;
+
+            return i;
+
+        }
+    }
+    return PCI_NONE;
+}
+
+uint16_t pci_dev_unregister(pcidev_t device) {
+
+    scoped_lock(&pci_dev_lock) {
+
+        for (size_t i = 0; i < PCI_DEVICES_MAX; i++) {
+
+            if (pci_devices[i].device != device)
+                continue;
+
+            pci_devices[i].device  = 0;
+            pci_devices[i].handler = NULL;
+            pci_devices[i].data    = NULL;
+
+            return i;
+        }
+    }
+    return PCI_NONE;
+}
+
+pcidev_t pci_dev_get_device(uint16_t index) {
+    DEBUG_ASSERT(index < PCI_DEVICES_MAX);
+    scoped_lock(&pci_dev_lock) {
+        return pci_devices[index].device;
+    }
+    return 0;
+}
+
+int pci_dev_call_handler(uint16_t index, irq_t irq) {
+    DEBUG_ASSERT(index < PCI_DEVICES_MAX);
+    scoped_lock(&pci_dev_lock) {
+        if (pci_devices[index].handler) {
+            pci_devices[index].handler(pci_devices[index].device, irq, pci_devices[index].data, pci_devices[index].vector);
+        } else {
+            return errno = ESRCH, -1;
+        }
+    }
+    return 0;
+}

--- a/drivers/dev/pci/pci_intx.c
+++ b/drivers/dev/pci/pci_intx.c
@@ -51,8 +51,7 @@ static spinlock_t pci_intx_lock = SPINLOCK_INIT_WITH_FLAGS(SPINLOCK_FLAGS_CPU_OW
 
 static void pci_intx_interrupt_handler(void* frame, irq_t irq) {
 
-    size_t i;
-    for (i = 0; i < PCI_INTX_DEVICES_MAX; i++) {
+    for (size_t i = 0; i < PCI_INTX_DEVICES_MAX; i++) {
 
         if (!pci_intx_devices[i].device)
             continue;
@@ -69,7 +68,6 @@ static void pci_intx_interrupt_handler(void* frame, irq_t irq) {
         if ((pci_read(pci_intx_devices[i].device, PCI_COMMAND, 2) & PCI_COMMAND_REG_INTR_DISABLE) != 0)
             continue;
 
-
         pci_intx_devices[i].handler(pci_intx_devices[i].device, irq, pci_intx_devices[i].data);
     }
 }
@@ -79,9 +77,7 @@ int pci_intx_map_irq(pcidev_t device, irq_t irq, pci_irq_handler_t handler, pci_
 
     spinlock_lock(&pci_intx_lock);
 
-
-    size_t i;
-    for (i = 0; i < PCI_INTX_DEVICES_MAX; i++) {
+    for (size_t i = 0; i < PCI_INTX_DEVICES_MAX; i++) {
 
         if (pci_intx_devices[i].device)
             continue;
@@ -91,7 +87,7 @@ int pci_intx_map_irq(pcidev_t device, irq_t irq, pci_irq_handler_t handler, pci_
         pci_intx_devices[i].device  = device;
         pci_intx_devices[i].handler = handler;
 
-        arch_intr_map_irq(irq, pci_intx_interrupt_handler);
+        arch_intr_map_irq(irq, pci_intx_interrupt_handler, ARCH_INTR_TYPE_PCI);
 
 
 #if DEBUG_LEVEL_TRACE

--- a/drivers/dev/pci/pci_intx.c
+++ b/drivers/dev/pci/pci_intx.c
@@ -36,109 +36,55 @@
 #include <dev/pci.h>
 
 
-#define PCI_INTX_DEVICES_MAX 128
-
-
-static struct {
-    pcidev_t device;
-    pci_irq_handler_t handler;
-    pci_irq_data_t data;
-} pci_intx_devices[PCI_INTX_DEVICES_MAX] = {0};
-
-static spinlock_t pci_intx_lock = SPINLOCK_INIT_WITH_FLAGS(SPINLOCK_FLAGS_CPU_OWNER);
-
-
-
 static void pci_intx_interrupt_handler(void* frame, irq_t irq) {
 
-    for (size_t i = 0; i < PCI_INTX_DEVICES_MAX; i++) {
+    for (size_t index = 0; index < PCI_DEVICES_MAX; index++) {
 
-        if (!pci_intx_devices[i].device)
+        pcidev_t device = pci_dev_get_device(index);
+        if (device == 0)
             continue;
 
-        if (!pci_intx_devices[i].handler)
+        if ((pci_read(device, PCI_INTERRUPT_LINE, 1) != irq))
             continue;
 
-        if ((pci_read(pci_intx_devices[i].device, PCI_INTERRUPT_LINE, 1) != irq))
+        if ((pci_read(device, PCI_STATUS, 2) & PCI_STATUS_REG_INTERRUPT) == 0)
             continue;
 
-        if ((pci_read(pci_intx_devices[i].device, PCI_STATUS, 2) & PCI_STATUS_REG_INTERRUPT) == 0)
+        if ((pci_read(device, PCI_COMMAND, 2) & PCI_COMMAND_REG_INTR_DISABLE) != 0)
             continue;
 
-        if ((pci_read(pci_intx_devices[i].device, PCI_COMMAND, 2) & PCI_COMMAND_REG_INTR_DISABLE) != 0)
-            continue;
+        pci_dev_call_handler(index, irq);
 
-        pci_intx_devices[i].handler(pci_intx_devices[i].device, irq, pci_intx_devices[i].data);
     }
 }
 
 
 int pci_intx_map_irq(pcidev_t device, irq_t irq, pci_irq_handler_t handler, pci_irq_data_t data) {
 
-    spinlock_lock(&pci_intx_lock);
-
-    for (size_t i = 0; i < PCI_INTX_DEVICES_MAX; i++) {
-
-        if (pci_intx_devices[i].device)
-            continue;
-
-
-        pci_intx_devices[i].data    = data;
-        pci_intx_devices[i].device  = device;
-        pci_intx_devices[i].handler = handler;
-
-        arch_intr_map_irq(irq, pci_intx_interrupt_handler, ARCH_INTR_TYPE_PCI);
-
-
-#if DEBUG_LEVEL_TRACE
-        kprintf("pci-intx: slot %d mapped for device %d [irq(%p), handler(%p), data(%p)]\n", i, device, irq, handler, data);
+    uint16_t index = pci_dev_register(device, handler, data, 0);
+    if (index == PCI_NONE) {
+#if DEBUG_LEVEL_FATAL
+        kprintf("pci-intx: ERROR! No more device slots available for device %d [irq(%p), handler(%p), data(%p)]\n", device, irq, handler, data);
 #endif
-
-        spinlock_unlock(&pci_intx_lock);
-        return 0;
+        return errno = ENOSPC, -1;
     }
 
-
-    spinlock_unlock(&pci_intx_lock);
-
-
-#if DEBUG_LEVEL_FATAL
-    kprintf("pci-intx: ERROR! No more device slots available for device %d [irq(%p), handler(%p), data(%p)]\n", device, irq, handler, data);
-#endif
-
-    return errno = ENOSPC, -1;
+    arch_intr_map_irq(irq, pci_intx_interrupt_handler, ARCH_INTR_TYPE_PCI);
+    return 0;
 }
 
 
 int pci_intx_unmap_irq(pcidev_t device) {
 
-    spinlock_lock(&pci_intx_lock);
-
-
-    size_t i;
-    for (i = 0; i < PCI_INTX_DEVICES_MAX; i++) {
-
-        if (pci_intx_devices[i].device != device)
-            continue;
-
-
-        pci_intx_devices[i].device  = 0;
-        pci_intx_devices[i].handler = NULL;
-        pci_intx_devices[i].data    = NULL;
-
-        spinlock_unlock(&pci_intx_lock);
-        return 0;
+    uint16_t index = pci_dev_unregister(device);
+    if (index == PCI_NONE) {
+#if DEBUG_LEVEL_FATAL
+        kprintf("pci-intx: ERROR! Device %d not found during unmap\n", device);
+#endif
+        return errno = ESRCH, -1;
     }
 
-
-    spinlock_unlock(&pci_intx_lock);
-
-
-#if DEBUG_LEVEL_FATAL
-    kprintf("pci-intx: ERROR! No device slot found for device %d\n", device);
-#endif
-
-    return errno = ESRCH, -1;
+    return 0;
 }
 
 

--- a/drivers/dev/pci/pci_msi.c
+++ b/drivers/dev/pci/pci_msi.c
@@ -68,7 +68,7 @@ int pci_find_msi(pcidev_t device, pci_msi_t* mptr) {
     uint8_t cap_next = 0;
     do {
 
-        if((cap_id = pci_read(device, caps + PCI_MSI_HDR_CAPID, sizeof(uint8_t)) != PCI_MSI_CAPID))
+        if ((cap_id = pci_read(device, caps + PCI_MSI_HDR_CAPID, sizeof(uint8_t))) != PCI_MSI_CAPID)
             return PCI_NONE;
 
         cap_next = pci_read(device, caps + PCI_MSI_HDR_CAPNEXT, sizeof(uint8_t));

--- a/drivers/dev/pci/pci_msi.c
+++ b/drivers/dev/pci/pci_msi.c
@@ -1,0 +1,157 @@
+/*
+ * Author:
+ *      Antonino Natale <antonio.natale97@hotmail.com>
+ *
+ * Copyright (c) 2013-2019 Antonino Natale
+ *
+ *
+ * This file is part of aplus.
+ *
+ * aplus is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * aplus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with aplus.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdatomic.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <aplus.h>
+#include <aplus/debug.h>
+#include <aplus/endian.h>
+#include <aplus/errno.h>
+#include <aplus/hal.h>
+#include <aplus/module.h>
+#include <aplus/vfs.h>
+
+#include <dev/interface.h>
+#include <dev/pci.h>
+
+
+static void pci_msi_interrupt_handler(void* frame, irq_t irq) {
+
+    DEBUG_ASSERT(irq > PCI_MSI_INTR_BASE - 1);
+    DEBUG_ASSERT(irq < PCI_MSI_INTR_BASE + PCI_DEVICES_MAX);
+
+    uint16_t index = irq - PCI_MSI_INTR_BASE;
+
+    pcidev_t device = pci_dev_get_device(index);
+    if (device == 0)
+        return;
+
+    pci_dev_call_handler(index, irq);
+}
+
+static bool pci_msi_is64bit(pcidev_t device, uintptr_t msi_cap) {
+    return !!(pci_read(device, msi_cap + PCI_MSI_HDR_MSGCTL, sizeof(uint16_t)) & PCI_MSI_MSGCTL_ADDR_64BIT);
+}
+
+int pci_find_msi(pcidev_t device, pci_msi_t* mptr) {
+
+    uintptr_t caps;
+    if ((caps = pci_find_capabilities(device)) == PCI_NONE)
+        return PCI_NONE;
+
+    if (mptr)
+        mptr->msi_cap = caps;
+
+    uint8_t cap_id = 0;
+    uint8_t cap_next = 0;
+    do {
+
+        if((cap_id = pci_read(device, caps + PCI_MSI_HDR_CAPID, sizeof(uint8_t)) != PCI_MSI_CAPID))
+            return PCI_NONE;
+
+        cap_next = pci_read(device, caps + PCI_MSI_HDR_CAPNEXT, sizeof(uint8_t));
+        
+
+        uint16_t msgctl = pci_read(device, caps + PCI_MSI_HDR_MSGCTL, sizeof(uint16_t));
+        msgctl &= ~PCI_MSI_MSGCTL_ENABLE;
+        msgctl &= ~PCI_MSI_MSGCTL_MSG_COUNT_MASK;
+        pci_write(device, caps + PCI_MSI_HDR_MSGCTL, sizeof(uint16_t), msgctl);
+
+    } while((caps = cap_next) != 0);
+
+    return 0;
+}
+
+
+
+void pci_msi_enable(pcidev_t device, pci_msi_t* msi) {
+#if DEBUG_LEVEL_TRACE
+    DEBUG_ASSERT(pci_read(device, msi->msi_cap + PCI_MSI_HDR_CAPID, sizeof(uint8_t)) == PCI_MSI_CAPID);
+#endif
+
+    uint16_t msgctl = pci_read(device, msi->msi_cap + PCI_MSI_HDR_MSGCTL, sizeof(uint16_t));
+    msgctl |= PCI_MSI_MSGCTL_ENABLE;
+    pci_write(device, msi->msi_cap + PCI_MSI_HDR_MSGCTL, sizeof(uint16_t), msgctl);
+}
+
+void pci_msi_disable(pcidev_t device, pci_msi_t* msi) {
+#if DEBUG_LEVEL_TRACE
+    DEBUG_ASSERT(pci_read(device, msi->msi_cap + PCI_MSI_HDR_CAPID, sizeof(uint8_t)) == PCI_MSI_CAPID);
+#endif
+
+    uint16_t msgctl = pci_read(device, msi->msi_cap + PCI_MSI_HDR_MSGCTL, sizeof(uint16_t));
+    msgctl &= ~PCI_MSI_MSGCTL_ENABLE;
+    pci_write(device, msi->msi_cap + PCI_MSI_HDR_MSGCTL, sizeof(uint16_t), msgctl);
+}
+
+bool pci_msi_is_enabled(pcidev_t device, pci_msi_t* msi) {
+#if DEBUG_LEVEL_TRACE
+    DEBUG_ASSERT(pci_read(device, msi->msi_cap + PCI_MSI_HDR_CAPID, sizeof(uint8_t)) == PCI_MSI_CAPID);
+#endif
+
+    return (pci_read(device, msi->msi_cap + PCI_MSI_HDR_MSGCTL, sizeof(uint16_t)) & PCI_MSI_MSGCTL_ENABLE) != 0;
+}
+
+int pci_msi_map_irq(pcidev_t device, pci_msi_t* msi, pci_irq_handler_t handler, pci_irq_data_t data) {
+
+    uint16_t index = pci_dev_register(device, handler, data, 0);
+    if (index == PCI_NONE) {
+#if DEBUG_LEVEL_FATAL
+        kprintf("pci-msi: ERROR! No more device slots available for device %d [handler(%p), data(%p)]\n", device, handler, data);
+#endif
+        return errno = ENOSPC, -1;
+    }
+
+    arch_intr_map_irq(index + PCI_MSI_INTR_BASE, pci_msi_interrupt_handler, ARCH_INTR_TYPE_MSI);
+
+    if (pci_msi_is64bit(device, msi->msi_cap)) {
+        pci_write(device, msi->msi_cap + PCI_MSI_HDR_MSGADDR, sizeof(uint64_t), 0xFEE00000 | ((uint64_t)(current_cpu->id) << 12));
+        pci_write(device, msi->msi_cap + PCI_MSI_HDR_MSGADDR + sizeof(uint64_t), sizeof(uint16_t), index + PCI_MSI_INTR_BASE + 0x20);
+    } else {
+        pci_write(device, msi->msi_cap + PCI_MSI_HDR_MSGADDR, sizeof(uint32_t), 0xFEE00000 | (current_cpu->id << 12));
+        pci_write(device, msi->msi_cap + PCI_MSI_HDR_MSGADDR + sizeof(uint32_t), sizeof(uint16_t), index + PCI_MSI_INTR_BASE + 0x20);
+    }
+
+    #if DEBUG_LEVEL_TRACE
+    kprintf("pci-msi: slot %d mapped for device %d [handler(%p), data(%p)]\n", index, device, handler, data);
+    #endif
+
+    atomic_thread_fence(memory_order_seq_cst);
+    return 0;
+}
+
+
+int pci_msi_unmap_irq(pcidev_t device, pci_msi_t* msi) {
+
+    uint16_t index = pci_dev_unregister(device);
+    if (index == PCI_NONE) {
+#if DEBUG_LEVEL_FATAL
+        kprintf("pci-msi: ERROR! No device slot found for device %d\n", device);
+#endif
+        return errno = ESRCH, -1;
+    }
+
+    return 0;
+}

--- a/drivers/dev/pci/pci_msix.c
+++ b/drivers/dev/pci/pci_msix.c
@@ -207,7 +207,7 @@ int pci_msix_unmap_irq(pcidev_t device, pci_msix_t* msix) {
     uint16_t index = pci_dev_unregister(device);
     if (index == PCI_NONE) {
 #if DEBUG_LEVEL_FATAL
-        kprintf("pci-msi: ERROR! No device slot found for device %d\n", device);
+        kprintf("pci-msix: ERROR! No device slot found for device %d\n", device);
 #endif
         return errno = ESRCH, -1;
     }

--- a/drivers/dev/pci/pci_msix.c
+++ b/drivers/dev/pci/pci_msix.c
@@ -37,62 +37,34 @@
 #include <dev/pci.h>
 
 
-
-#define PCI_MSIX_DEVICES_MAX 128
-#define PCI_MSIX_INTR_BASE   65
-
-
-static struct {
-    pci_irq_handler_t handler;
-    pci_irq_data_t data;
-    pcidev_t device;
-    uint16_t index;
-} pci_msix_devices[PCI_MSIX_DEVICES_MAX] = {0};
-
-static spinlock_t pci_msix_lock = SPINLOCK_INIT_WITH_FLAGS(SPINLOCK_FLAGS_CPU_OWNER);
-
-
-
 static void pci_msix_interrupt_handler(void* frame, irq_t irq) {
 
-    DEBUG_ASSERT(irq > PCI_MSIX_INTR_BASE - 1);
-    DEBUG_ASSERT(irq < PCI_MSIX_INTR_BASE + PCI_MSIX_DEVICES_MAX);
+    DEBUG_ASSERT(irq > PCI_MSI_INTR_BASE - 1);
+    DEBUG_ASSERT(irq < PCI_MSI_INTR_BASE + PCI_DEVICES_MAX);
 
+    uint16_t index = irq - PCI_MSI_INTR_BASE;
 
-    irq -= PCI_MSIX_INTR_BASE;
-
-    if (!pci_msix_devices[irq].device)
+    pcidev_t device = pci_dev_get_device(index);
+    if (device == 0)
         return;
 
-    if (!pci_msix_devices[irq].handler)
-        return;
-
-
-    pci_msix_devices[irq].handler(pci_msix_devices[irq].device, pci_msix_devices[irq].index, pci_msix_devices[irq].data);
+    pci_dev_call_handler(index, irq);
 }
 
 
-
 int pci_find_msix(pcidev_t device, pci_msix_t* mptr) {
-
-    DEBUG_ASSERT(device);
-
 
     uintptr_t caps;
     if ((caps = pci_find_capabilities(device)) == PCI_NONE)
         return PCI_NONE;
 
-
     pci_msix_t msix;
-
     do {
 
         pci_memcpy(device, &msix.msix_pci, caps, sizeof(pci_msix_t));
 
         if (msix.msix_pci.pci_capid != PCI_MSIX_CAPID)
             continue;
-
-
 
         if (msix.msix_pci.pci_bir > 5) {
 #if DEBUG_LEVEL_FATAL
@@ -102,32 +74,44 @@ int pci_find_msix(pcidev_t device, pci_msix_t* mptr) {
         }
 
 
+        uintptr_t pci_bir_address = 0UL;
+        size_t pci_bir_size = 0UL;
 
-        uintptr_t mmio = 0UL;
-
+        uintptr_t pci_pba_address = 0UL;
+        size_t pci_pba_size = 0UL;
 
 #if defined(__x86_64__) || defined(__aarch64__)
-        if (pci_is_64bit(device, PCI_BAR(msix.msix_pci.pci_bir)))
-            mmio = pci_read(device, PCI_BAR(msix.msix_pci.pci_bir), 8) & PCI_BAR_MM_MASK;
-        else
+        if (pci_is_64bit(device, PCI_BAR(msix.msix_pci.pci_bir))) {
+            pci_bir_address = pci_read(device, PCI_BAR(msix.msix_pci.pci_bir), 8) & PCI_BAR_MM_MASK;
+            pci_bir_size    = pci_bar_size(device, PCI_BAR(msix.msix_pci.pci_bir), 8);
+            pci_pba_address = pci_read(device, PCI_BAR(msix.msix_pci.pci_pending_bir), 8) & PCI_BAR_MM_MASK;
+            pci_pba_size    = pci_bar_size(device, PCI_BAR(msix.msix_pci.pci_pending_bir), 8);
+        } else
 #endif
-            mmio = pci_read(device, PCI_BAR(msix.msix_pci.pci_bir), 4) & PCI_BAR_MM_MASK;
+        {
+            pci_bir_address = pci_read(device, PCI_BAR(msix.msix_pci.pci_bir), 4) & PCI_BAR_MM_MASK;
+            pci_bir_size    = pci_bar_size(device, PCI_BAR(msix.msix_pci.pci_bir), 4);
+            pci_pba_address = pci_read(device, PCI_BAR(msix.msix_pci.pci_pending_bir), 4) & PCI_BAR_MM_MASK;
+            pci_pba_size    = pci_bar_size(device, PCI_BAR(msix.msix_pci.pci_pending_bir), 4);
+        }
 
+        DEBUG_ASSERT(pci_bir_address);
+        DEBUG_ASSERT(pci_bir_size);
+        DEBUG_ASSERT(pci_pba_address);
+        DEBUG_ASSERT(pci_pba_size);
 
-        DEBUG_ASSERT(mmio);
+        arch_vmm_map(&core->bsp.address_space, pci_bir_address, pci_bir_address, pci_bir_size, ARCH_VMM_MAP_FIXED | ARCH_VMM_MAP_RDWR | ARCH_VMM_MAP_UNCACHED | ARCH_VMM_MAP_NOEXEC);
 
+        if (msix.msix_pci.pci_bir != msix.msix_pci.pci_pending_bir) {
+            arch_vmm_map(&core->bsp.address_space, pci_pba_address, pci_pba_address, pci_pba_size, ARCH_VMM_MAP_FIXED | ARCH_VMM_MAP_RDWR | ARCH_VMM_MAP_UNCACHED | ARCH_VMM_MAP_NOEXEC);
+        } 
 
-        mmio += msix.msix_pci.pci_offset;
-
-        arch_vmm_map(&core->bsp.address_space, mmio, mmio, msix.msix_pci.pci_msgctl_table_size * sizeof(pci_msix_row_t), ARCH_VMM_MAP_FIXED | ARCH_VMM_MAP_RDWR | ARCH_VMM_MAP_UNCACHED | ARCH_VMM_MAP_NOEXEC);
-
+        pci_bir_address += msix.msix_pci.pci_offset;
+        pci_pba_address += msix.msix_pci.pci_pending_offset;
 
         msix.msix_cap  = caps;
-        msix.msix_rows = (pci_msix_row_t volatile*)mmio;
-
-
-
-        // Mask all interrupts
+        msix.msix_rows = (pci_msix_row_t volatile*)pci_bir_address;
+        msix.msix_pba  = (pci_msix_pba_t volatile*)pci_pba_address;
 
         for (size_t i = 0; i < msix.msix_pci.pci_msgctl_table_size + 1; i++)
             pci_msix_mask(device, &msix, i);
@@ -135,161 +119,103 @@ int pci_find_msix(pcidev_t device, pci_msix_t* mptr) {
         if (mptr)
             memcpy(mptr, &msix, sizeof(pci_msix_t));
 
-
         return 0;
 
-
     } while ((caps = msix.msix_pci.pci_capnext) != 0);
-
 
     return PCI_NONE;
 }
 
 
-
 void pci_msix_enable(pcidev_t device, pci_msix_t* msix) {
-
-    DEBUG_ASSERT(device);
-    DEBUG_ASSERT(msix);
-    DEBUG_ASSERT(msix->msix_cap);
-
 #if DEBUG_LEVEL_TRACE
     DEBUG_ASSERT(pci_read(device, msix->msix_cap, 1) == PCI_MSIX_CAPID);
 #endif
 
-    return pci_write(device, msix->msix_cap + 2, 2, pci_read(device, msix->msix_cap + 2, 2) | PCI_MSIX_ENABLE);
+    uint16_t pci_msgctl = pci_read(device, msix->msix_cap + PCI_MSIX_HDR_MSGCTL, sizeof(uint16_t));
+    pci_msgctl |= PCI_MSIX_MSGCTL_ENABLE;
+    pci_msgctl &= ~PCI_MSIX_MSGCTL_MASK;
+    pci_write(device, msix->msix_cap + PCI_MSIX_HDR_MSGCTL, sizeof(uint16_t), pci_msgctl);
 }
 
 void pci_msix_disable(pcidev_t device, pci_msix_t* msix) {
-
-    DEBUG_ASSERT(device);
-    DEBUG_ASSERT(msix);
-    DEBUG_ASSERT(msix->msix_cap);
-
 #if DEBUG_LEVEL_TRACE
     DEBUG_ASSERT(pci_read(device, msix->msix_cap, 1) == PCI_MSIX_CAPID);
 #endif
 
-    return pci_write(device, msix->msix_cap + 2, 2, pci_read(device, msix->msix_cap + 2, 2) & ~PCI_MSIX_ENABLE);
+    uint16_t pci_msgctl = pci_read(device, msix->msix_cap + PCI_MSIX_HDR_MSGCTL, sizeof(uint16_t));
+    pci_msgctl &= ~PCI_MSIX_MSGCTL_ENABLE;
+    pci_msgctl |= PCI_MSIX_MSGCTL_MASK;
+    pci_write(device, msix->msix_cap + PCI_MSIX_HDR_MSGCTL, sizeof(uint16_t), pci_msgctl);
+}
+
+bool pci_msix_is_enabled(pcidev_t device, pci_msix_t* msix) {
+#if DEBUG_LEVEL_TRACE
+    DEBUG_ASSERT(pci_read(device, msix->msix_cap, 1) == PCI_MSIX_CAPID);
+#endif
+
+    return !!(pci_read(device, msix->msix_cap + PCI_MSIX_HDR_MSGCTL, sizeof(uint16_t)) & PCI_MSIX_MSGCTL_ENABLE);
 }
 
 
 void pci_msix_mask(pcidev_t device, pci_msix_t* msix, uint32_t index) {
-
-    DEBUG_ASSERT(device);
-    DEBUG_ASSERT(msix);
-    DEBUG_ASSERT(msix->msix_rows);
-
     atomic_thread_fence(memory_order_acquire);
     msix->msix_rows[index].pr_ctl |= PCI_MSIX_INTR_MASK;
     atomic_thread_fence(memory_order_release);
 }
 
 void pci_msix_unmask(pcidev_t device, pci_msix_t* msix, uint32_t index) {
-
-    DEBUG_ASSERT(device);
-    DEBUG_ASSERT(msix);
-    DEBUG_ASSERT(msix->msix_rows);
-
     atomic_thread_fence(memory_order_acquire);
     msix->msix_rows[index].pr_ctl &= ~PCI_MSIX_INTR_MASK;
     atomic_thread_fence(memory_order_release);
 }
 
-
-
-int pci_msix_map_irq(pcidev_t device, pci_msix_t* msix, pci_irq_handler_t handler, pci_irq_data_t data, uint16_t index) {
+int pci_msix_map_irq(pcidev_t device, pci_msix_t* msix, pci_irq_handler_t handler, pci_irq_data_t data, uint16_t vector) {
 
     DEBUG_ASSERT(device);
     DEBUG_ASSERT(handler);
     DEBUG_ASSERT(msix);
     DEBUG_ASSERT(msix->msix_rows);
-    DEBUG_ASSERT(msix->msix_pci.pci_msgctl_table_size >= index);
+    DEBUG_ASSERT(msix->msix_pci.pci_msgctl_table_size >= vector);
 
 
-    spinlock_lock(&pci_msix_lock);
-
-    size_t i;
-    for (i = 0; i < PCI_MSIX_DEVICES_MAX; i++) {
-
-        if (pci_msix_devices[i].device)
-            continue;
-
-        if (pci_msix_devices[i].handler)
-            continue;
-
-
-        pci_msix_devices[i].index   = index;
-        pci_msix_devices[i].device  = device;
-        pci_msix_devices[i].handler = handler;
-        pci_msix_devices[i].data    = data;
-
-        arch_intr_map_irq_without_ioapic(i + PCI_MSIX_INTR_BASE, pci_msix_interrupt_handler);
-
-
-        msix->msix_rows[index].pr_address = cpu_to_le64(0xFEE00000 | (current_cpu->id << 12) | (1 << 14));
-        msix->msix_rows[index].pr_data    = cpu_to_le32(i + PCI_MSIX_INTR_BASE);
-        msix->msix_rows[index].pr_ctl     = cpu_to_le32(le32_to_cpu(msix->msix_rows[index].pr_ctl) | PCI_MSIX_INTR_MASK);
-
-        atomic_thread_fence(memory_order_seq_cst);
-
-
-#if DEBUG_LEVEL_TRACE
-        kprintf("pci-msix: slot %d mapped for device %d [index(%p), handler(%p), data(%p)]\n", i, device, index, handler, data);
+    uint16_t index = pci_dev_register(device, handler, data, vector);
+    if (index == PCI_NONE) {
+#if DEBUG_LEVEL_FATAL
+        kprintf("pci-msix: ERROR! No more device slots available for device %d [handler(%p), data(%p)]\n", device, handler, data);
 #endif
-
-        spinlock_unlock(&pci_msix_lock);
-        return 0;
+        return errno = ENOSPC, -1;
     }
 
+    msix->msix_rows[index].pr_address = cpu_to_le64(0xFEE00000 | (current_cpu->id << 12));
+    msix->msix_rows[index].pr_data    = cpu_to_le32(index + PCI_MSIX_INTR_BASE + 0x20);
+    msix->msix_rows[index].pr_ctl     = cpu_to_le32(le32_to_cpu(msix->msix_rows[index].pr_ctl) | PCI_MSIX_INTR_MASK);
+            
+    arch_intr_map_irq(index + PCI_MSIX_INTR_BASE, pci_msix_interrupt_handler, ARCH_INTR_TYPE_MSI);
 
-    spinlock_unlock(&pci_msix_lock);
-
-
-#if DEBUG_LEVEL_FATAL
-    kprintf("pci-msix: ERROR! No more device slots available for device %d [index(%p), handler(%p), data(%p)]\n", device, index, handler, data);
+#if DEBUG_LEVEL_TRACE
+    kprintf("pci-msix: slot %d mapped for device %d [vector(%p), handler(%p), data(%p)]\n", index, device, vector, handler, data);
 #endif
 
-    return errno = ENOSPC, -1;
+    atomic_thread_fence(memory_order_seq_cst);
+    return 0;
 }
 
 
 int pci_msix_unmap_irq(pcidev_t device, pci_msix_t* msix) {
 
-    spinlock_lock(&pci_msix_lock);
-
-
-    size_t i;
-    for (i = 0; i < PCI_MSIX_DEVICES_MAX; i++) {
-
-        if (pci_msix_devices[i].device != device)
-            continue;
-
-
-        msix->msix_rows[pci_msix_devices[i].index].pr_address = 0;
-        msix->msix_rows[pci_msix_devices[i].index].pr_data    = 0;
-        msix->msix_rows[pci_msix_devices[i].index].pr_ctl     = cpu_to_le32(le32_to_cpu(msix->msix_rows[pci_msix_devices[i].index].pr_ctl) | PCI_MSIX_INTR_MASK);
-
-        atomic_thread_fence(memory_order_seq_cst);
-
-
-        pci_msix_devices[i].index   = 0;
-        pci_msix_devices[i].device  = 0;
-        pci_msix_devices[i].handler = NULL;
-        pci_msix_devices[i].data    = NULL;
-
-
-        spinlock_unlock(&pci_msix_lock);
-        return 0;
+    uint16_t index = pci_dev_unregister(device);
+    if (index == PCI_NONE) {
+#if DEBUG_LEVEL_FATAL
+        kprintf("pci-msi: ERROR! No device slot found for device %d\n", device);
+#endif
+        return errno = ESRCH, -1;
     }
 
+    msix->msix_rows[index].pr_address = 0;
+    msix->msix_rows[index].pr_data    = 0;
+    msix->msix_rows[index].pr_ctl     = cpu_to_le32(le32_to_cpu(msix->msix_rows[index].pr_ctl) | PCI_MSIX_INTR_MASK);
 
-    spinlock_unlock(&pci_msix_lock);
-
-
-#if DEBUG_LEVEL_FATAL
-    kprintf("pci-msix: ERROR! No device slot found for device %d\n", device);
-#endif
-
-    return errno = ESRCH, -1;
+    atomic_thread_fence(memory_order_seq_cst);
+    return 0;
 }

--- a/drivers/dev/pci/pci_msix.c
+++ b/drivers/dev/pci/pci_msix.c
@@ -187,9 +187,25 @@ int pci_msix_map_irq(pcidev_t device, pci_msix_t* msix, pci_irq_handler_t handle
         return errno = ENOSPC, -1;
     }
 
-    msix->msix_rows[index].pr_address = cpu_to_le64(0xFEE00000 | (current_cpu->id << 12));
-    msix->msix_rows[index].pr_data    = cpu_to_le32(index + PCI_MSIX_INTR_BASE + 0x20);
-    msix->msix_rows[index].pr_ctl     = cpu_to_le32(le32_to_cpu(msix->msix_rows[index].pr_ctl) | PCI_MSIX_INTR_MASK);
+    size_t i = 0;
+    for (i = 0; i < msix->msix_pci.pci_msgctl_table_size + 1; i++) {
+        
+        if (msix->msix_rows[i].pr_address != 0)
+            continue;
+
+        msix->msix_rows[i].pr_address = cpu_to_le64(0xFEE00000 | (current_cpu->id << 12));
+        msix->msix_rows[i].pr_data    = cpu_to_le32(index + PCI_MSIX_INTR_BASE + 0x20);
+        msix->msix_rows[i].pr_ctl     = cpu_to_le32(le32_to_cpu(msix->msix_rows[i].pr_ctl) | PCI_MSIX_INTR_MASK);
+
+    }
+
+    if (i == msix->msix_pci.pci_msgctl_table_size + 1) {
+#if DEBUG_LEVEL_FATAL
+        kprintf("pci-msix: ERROR! No more MSI-X table slots available for device %d [handler(%p), data(%p)]\n", device, handler, data);
+#endif
+        pci_dev_unregister(device);
+        return errno = ENOSPC, -1;
+    }
             
     arch_intr_map_irq(index + PCI_MSIX_INTR_BASE, pci_msix_interrupt_handler, ARCH_INTR_TYPE_MSI);
 
@@ -197,7 +213,6 @@ int pci_msix_map_irq(pcidev_t device, pci_msix_t* msix, pci_irq_handler_t handle
     kprintf("pci-msix: slot %d mapped for device %d [vector(%p), handler(%p), data(%p)]\n", index, device, vector, handler, data);
 #endif
 
-    atomic_thread_fence(memory_order_seq_cst);
     return 0;
 }
 
@@ -212,10 +227,23 @@ int pci_msix_unmap_irq(pcidev_t device, pci_msix_t* msix) {
         return errno = ESRCH, -1;
     }
 
-    msix->msix_rows[index].pr_address = 0;
-    msix->msix_rows[index].pr_data    = 0;
-    msix->msix_rows[index].pr_ctl     = cpu_to_le32(le32_to_cpu(msix->msix_rows[index].pr_ctl) | PCI_MSIX_INTR_MASK);
+    size_t i;
+    for (i = 0; i < msix->msix_pci.pci_msgctl_table_size + 1; i++) {
+        
+        if (msix->msix_rows[i].pr_data != cpu_to_le32(index + PCI_MSIX_INTR_BASE + 0x20))
+            continue;
+        
+        msix->msix_rows[i].pr_address = 0;
+        msix->msix_rows[i].pr_data    = 0;
+        msix->msix_rows[i].pr_ctl     = cpu_to_le32(le32_to_cpu(msix->msix_rows[i].pr_ctl) | PCI_MSIX_INTR_MASK);
 
-    atomic_thread_fence(memory_order_seq_cst);
+    }
+
+    if (i == msix->msix_pci.pci_msgctl_table_size + 1) {
+#if DEBUG_LEVEL_FATAL
+        kprintf("pci-msix: WARN! No MSI-X table slot found for device %d\n", device);
+#endif
+    }
+
     return 0;
 }

--- a/drivers/platform/pc/arch/pci/main.c
+++ b/drivers/platform/pc/arch/pci/main.c
@@ -63,9 +63,9 @@ void pci_write(pcidev_t device, int field, size_t size, uint64_t value) {
             case 4:
                 return outl(PCI_VALUE_PORT, cpu_to_le32(value));
             case 2:
-                return outw(PCI_VALUE_PORT, cpu_to_le16(value));
+                return outw(PCI_VALUE_PORT + (field & 2), cpu_to_le16(value));
             case 1:
-                return outb(PCI_VALUE_PORT, value);
+                return outb(PCI_VALUE_PORT + (field & 3), value);
             default:
                 PANIC_ASSERT(0 && "Bug: Invalid Size!");
         }
@@ -83,7 +83,7 @@ uint64_t pci_read(pcidev_t device, int field, size_t size) {
         outl(PCI_ADDRESS_PORT, pci_get_addr(device, field + 4));
         uint64_t high = inl(PCI_VALUE_PORT);
 
-        return (le64_to_cpu(high) << 32ULL) | le64_to_cpu(low);
+        return (le32_to_cpu(high) << 32ULL) | le32_to_cpu(low);
 
     } else {
 

--- a/drivers/platform/pc/block/ahci/main.c
+++ b/drivers/platform/pc/block/ahci/main.c
@@ -1363,7 +1363,7 @@ void init(const char* args) {
                 continue;
 
 
-            device_t* d = (device_t*)kcalloc(sizeof(device_t), 1, GFP_KERNEL);
+            device_t* d = (device_t*)kcalloc(1, sizeof(device_t), GFP_KERNEL);
 
             strncpy(d->name, "sda", DEVICE_MAXNAMELEN);
             strncpy(d->description, "SATA disk device", DEVICE_MAXDESCLEN);
@@ -1401,7 +1401,7 @@ void init(const char* args) {
                 continue;
 
 
-            device_t* d = (device_t*)kcalloc(sizeof(device_t), 1, GFP_KERNEL);
+            device_t* d = (device_t*)kcalloc(1, sizeof(device_t), GFP_KERNEL);
 
             strncpy(d->name, "scd0", DEVICE_MAXNAMELEN);
             strncpy(d->description, "SATA CD-ROM device", DEVICE_MAXDESCLEN);

--- a/drivers/platform/pc/block/ahci/main.c
+++ b/drivers/platform/pc/block/ahci/main.c
@@ -1448,8 +1448,7 @@ void dnit(void) {
         ahci->hba->ghc &= ~AHCI_HBA_GHC_AE;
         ahci->hba->is = ~0;
 
-
-        arch_intr_unmap_irq(ahci->irq);
+        pci_intx_unmap_irq(ahci->deviceid);
         arch_vmm_unmap(&core->bsp.address_space, (uintptr_t)ahci->hba, AHCI_HBA_SIZE);
 
         /* TODO: implements ahci de-initialitation */

--- a/drivers/platform/pc/input/ps2/main.c
+++ b/drivers/platform/pc/input/ps2/main.c
@@ -530,15 +530,15 @@ void init(const char* args) {
 
 
 
-    arch_intr_map_irq(1, ps2_keyboard_irq);
-    arch_intr_map_irq(12, ps2_mouse_irq);
+    arch_intr_map_irq(1, ps2_keyboard_irq, ARCH_INTR_TYPE_DEFAULT);
+    arch_intr_map_irq(12, ps2_mouse_irq, ARCH_INTR_TYPE_DEFAULT);
 }
 
 
 void dnit(void) {
 
-    arch_intr_unmap_irq(1);
-    arch_intr_unmap_irq(12);
+    arch_intr_unmap_irq(1, ARCH_INTR_TYPE_DEFAULT);
+    arch_intr_unmap_irq(12, ARCH_INTR_TYPE_DEFAULT);
 
     device_unlink(&keyboard);
     device_unlink(&mouse);

--- a/drivers/tty/ptmx/main.c
+++ b/drivers/tty/ptmx/main.c
@@ -49,7 +49,7 @@ static inode_t* ptmx_open(inode_t* inode, int flags) {
     DEBUG_ASSERT(inode);
 
 
-    inode_t* ptmx = (inode_t*)kcalloc(sizeof(inode_t), 1, GFP_USER);
+    inode_t* ptmx = (inode_t*)kcalloc(1, sizeof(inode_t), GFP_USER);
 
     if (unlikely(!ptmx))
         goto fail_1;

--- a/drivers/tty/pts/main.c
+++ b/drivers/tty/pts/main.c
@@ -139,7 +139,7 @@ static inode_t* pts_finddir(inode_t* inode, const char* name) {
             DEBUG_ASSERT(queue->ptmx);
 
 
-            inode_t* d = (inode_t*)kcalloc(sizeof(inode_t), 1, GFP_USER);
+            inode_t* d = (inode_t*)kcalloc(1, sizeof(inode_t), GFP_USER);
 
             strncpy(d->name, name, CONFIG_MAXNAMLEN);
 

--- a/drivers/tty/pty/main.c
+++ b/drivers/tty/pty/main.c
@@ -792,7 +792,7 @@ pty_t* pty_create(inode_t* ptmx, int flags) {
     DEBUG_ASSERT(ptmx);
 
 
-    struct pty* pty = (struct pty*)kcalloc(sizeof(struct pty), 1, GFP_USER);
+    struct pty* pty = (struct pty*)kcalloc(1, sizeof(struct pty), GFP_USER);
 
     if (unlikely(!pty))
         return NULL;

--- a/drivers/virtio/virtio-console/main.c
+++ b/drivers/virtio/virtio-console/main.c
@@ -51,17 +51,19 @@ MODULE_LICENSE("GPL");
 static void virtconsole_init(device_t*);
 static void virtconsole_dnit(device_t*);
 static void virtconsole_reset(device_t*);
+static ssize_t virtconsole_write(device_t*, const void*, size_t);
+static ssize_t virtconsole_read(device_t*, void*, size_t);
 
 
 device_t device = {
 
     .type = DEVICE_TYPE_CHAR,
 
-    .name        = "vport0p1",
+    .name        = "hvc0",
     .description = "VIRTIO Console Device",
 
-    .major = 10, // FIXME: change values
-    .minor = 243,
+    .major = 229,
+    .minor = 0,
 
     .status = DEVICE_STATUS_UNKNOWN,
 
@@ -70,44 +72,18 @@ device_t device = {
     .reset = virtconsole_reset,
 
     .chr.io = CHAR_IO_NBF,
-    //.chr.write = &virtconsole_write,
-    //.chr.read =  &virtconsole_read,
+    .chr.write = virtconsole_write,
+    .chr.read  = virtconsole_read,
 
 };
 
 
-
-static void virtconsole_init(device_t* device) {
-
-    DEBUG_ASSERT(device);
-    DEBUG_ASSERT(device->mmiobase);
-
-
-    virtconsole_reset(device);
-}
-
-
-static void virtconsole_dnit(device_t* device) {
-
-    DEBUG_ASSERT(device);
-    DEBUG_ASSERT(device->mmiobase);
-}
-
-
-static void virtconsole_reset(device_t* device) {
-
-    DEBUG_ASSERT(device);
-}
-
 static int negotiate_features(struct virtio_driver* driver, uint32_t* features, size_t index) {
-
     if (index == 0) {
-
         *features &= ~VIRTIO_CONSOLE_F_SIZE;
         *features &= ~VIRTIO_CONSOLE_F_MULTIPORT;
         *features &= ~VIRTIO_CONSOLE_F_EMERG_WRITE;
     }
-
     return 0;
 }
 
@@ -115,12 +91,12 @@ static int setup_config(struct virtio_driver* driver, uintptr_t device_config) {
     return 0;
 }
 
-static int interrupt_handler(pcidev_t device, irq_t vector, struct virtio_driver* driver) {
-    return kprintf("!!!!!!!!!!!!!!!RECEIVED MSI-X INTERRUPT!!!!!!!!!!!!!!!!!!\n"), 0;
-}
-
-
 static void pci_find(pcidev_t device, uint16_t vid, uint16_t did, void* arg) {
+    
+    device_t* config = (device_t*)arg;
+
+    if (config->userdata != NULL)
+        return;
 
     if (vid != VIRTIO_PCI_VENDOR)
         return;
@@ -129,38 +105,76 @@ static void pci_find(pcidev_t device, uint16_t vid, uint16_t did, void* arg) {
         return;
 
 
-    struct virtio_driver driver = {0};
+    struct virtio_driver* driver = kcalloc(1, sizeof(struct virtio_driver), GFP_KERNEL);
 
-    driver.type             = VIRTIO_DEVICE_TYPE_CONSOLE;
-    driver.device           = device;
-    driver.send_window_size = 4096;
-    driver.recv_window_size = 4096;
+    driver->type             = VIRTIO_DEVICE_TYPE_CONSOLE;
+    driver->device           = device;
+    driver->send_window_size = 4096;
+    driver->recv_window_size = 4096;
+    driver->max_queues       = 2;
 
-    driver.negotiate = &negotiate_features;
-    driver.setup     = &setup_config;
-    driver.interrupt = &interrupt_handler;
+    driver->negotiate = &negotiate_features;
+    driver->setup     = &setup_config;
+    driver->interrupt = NULL;
 
 
-    if (virtio_pci_init(&driver) < 0) {
-
+    if (virtio_pci_init(driver) < 0) {
 #if DEBUG_LEVEL_ERROR
         kprintf("virtio-console: device %d (%X:%X) initialization failed\n", device, vid, did);
 #endif
-
         return;
     }
 
+    config->userdata = driver;
 
-    virtq_send(&driver, VIRTIO_CONSOLE_PORT_TX(0), "Hello World!", 13);
+    virtq_send(driver, VIRTIO_CONSOLE_PORT_TX(0), "Hello World!", 13);
 }
 
+
+static void virtconsole_init(device_t* device) {
+    DEBUG_ASSERT(device);
+    virtconsole_reset(device);
+}
+
+static void virtconsole_dnit(device_t* device) {
+    DEBUG_ASSERT(device);
+}
+
+static void virtconsole_reset(device_t* device) {
+    DEBUG_ASSERT(device);
+}
+
+static ssize_t virtconsole_write(device_t* device, const void* buf, size_t size) {
+    DEBUG_ASSERT(device);
+    DEBUG_ASSERT(device->userdata);
+    DEBUG_ASSERT(buf);
+
+    if (unlikely(size == 0))
+        return 0;
+
+    return virtq_send((struct virtio_driver*)device->userdata, VIRTIO_CONSOLE_PORT_TX(0), buf, size);
+}
+
+static ssize_t virtconsole_read(device_t* device, void* buf, size_t size) {
+    DEBUG_ASSERT(device);
+    DEBUG_ASSERT(device->userdata);
+    DEBUG_ASSERT(buf);
+
+    errno = ENOSYS;
+    return -1;
+}
 
 void init(const char* args) {
 
     if (strstr(core->boot.cmdline, "virtio=off"))
         return;
 
-    pci_scan(&pci_find, PCI_TYPE_ALL, NULL);
+    pci_scan(&pci_find, PCI_TYPE_ALL, &device);
+
+    if (device.userdata == NULL)
+        return;
+
+    device_mkdev(&device, 0644);
 }
 
 void dnit(void) {

--- a/drivers/virtio/virtio-gpu/main.c
+++ b/drivers/virtio/virtio-gpu/main.c
@@ -146,7 +146,7 @@ static void virtgpu_reset_framebuffer(device_t* device) {
     // __(virtgpu_cmd_set_scanout,                device->userdata, VIRTGPU_DISPLAY_PRIMARY, resource, 0, 0, device->vid.vs.xres, device->vid.vs.yres);
 
 
-    struct virtio_gpu_resp_display_info display_info;
+    struct virtio_gpu_resp_display_info display_info = {0};
 
     __(virtgpu_cmd_get_display_info, device->userdata, &display_info);
     __(virtgpu_cmd_get_display_info, device->userdata, &display_info);
@@ -318,10 +318,7 @@ static void pci_find(pcidev_t device, uint16_t vid, uint16_t did, void* arg) {
 
 
 
-    struct virtio_driver* virtio = kmalloc(sizeof(struct virtio_driver), GFP_KERNEL);
-
-    memset(virtio, 0, sizeof(struct virtio_driver));
-
+    struct virtio_driver* virtio = kcalloc(1, sizeof(struct virtio_driver), GFP_KERNEL);
 
     virtio->type             = VIRTIO_DEVICE_TYPE_GPU;
     virtio->device           = device;

--- a/drivers/virtio/virtio-pci/main.c
+++ b/drivers/virtio/virtio-pci/main.c
@@ -48,33 +48,32 @@ MODULE_AUTHOR("Antonino Natale");
 MODULE_LICENSE("GPL");
 
 
-static void virtio_pci_interrupt(pcidev_t device, irq_t vector, struct virtio_driver* driver) {
-
-    DEBUG_ASSERT(device);
-    DEBUG_ASSERT(driver);
-    DEBUG_ASSERT(driver->internals.isr_status);
-
-
-    uint32_t isr = mmio_r32(driver->internals.isr_status);
-
-
-    if (isr & VIRTIO_ISR_STATUS_QUEUE) {
+static void virtio_pci_interrupt(pcidev_t device, irq_t irq, struct virtio_driver* driver, uint16_t vector) {
 
 #if defined(CONFIG_HAVE_PCI_MSIX)
+
+    DEBUG_ASSERT(vector < driver->internals.num_queues + 1);
+
+    if (vector == driver->internals.num_queues) {
+        // TODO: handle config interrupt
+        kprintf("virtio-pci: WARN! received config interrupt!\n");
+    } else {
         virtq_flush(driver, vector);
+    }
+
 #else
+    uint32_t isr = mmio_r32(driver->internals.isr_status);
+
+    if (isr & VIRTIO_ISR_STATUS_QUEUE) {
         for (size_t i = 0; i < driver->internals.num_queues; i++)
             virtq_flush(driver, i);
-#endif
     }
-
 
     if (isr & VIRTIO_ISR_STATUS_CONFIG) {
-
-        // TODO...
+        // TODO: handle config interrupt
         kprintf("virtio-pci: WARN! received isr status config!\n");
     }
-
+#endif
 
     if (likely(driver->interrupt)) {
         driver->interrupt(device, vector, driver);
@@ -105,7 +104,6 @@ static uintptr_t virtio_pci_find_bar(struct virtio_driver* driver, uint8_t bar, 
     DEBUG_ASSERT(mmio);
     DEBUG_ASSERT(size);
 
-
     if ((driver->internals.bars & (1 << bar)) == 0) {
 
 #if DEBUG_LEVEL_TRACE
@@ -128,8 +126,6 @@ static int virtio_pci_init_common_cfg(struct virtio_driver* driver, uint8_t bar,
     DEBUG_ASSERT(driver);
     DEBUG_ASSERT(driver->device);
     DEBUG_ASSERT(bar >= 0 && bar <= 5);
-
-
 
 #if DEBUG_LEVEL_ERROR
     #define cfg_set_status_and_check(status)                                                                                          \
@@ -171,7 +167,7 @@ static int virtio_pci_init_common_cfg(struct virtio_driver* driver, uint8_t bar,
 
 
 #if DEBUG_LEVEL_TRACE
-    kprintf("virtio-pci: device %d reset successful [bar(%d), cfg(%p), queues(%d)]\n", driver->device, bar, cfg, cfg->num_queues);
+    kprintf("virtio-pci: device %d reset successful [bar(%d), cfg(%p), queues(%d)]\n", driver->device, bar, cfg, le16_to_cpu(cfg->num_queues));
 #endif
 
 
@@ -204,7 +200,7 @@ static int virtio_pci_init_common_cfg(struct virtio_driver* driver, uint8_t bar,
             atomic_thread_fence(memory_order_release);
 
 
-            if (cfg->driver_feature != features) {
+            if (cfg->driver_feature != cpu_to_le32(features)) {
 
 #if DEBUG_LEVEL_FATAL
                 kprintf("virtio-pci: FAIL! device %d failed features %d negotiation [user(%X), driver(%X), device(%X)]\n", driver->device, features, i, cfg->driver_feature, cfg->device_feature);
@@ -219,6 +215,17 @@ static int virtio_pci_init_common_cfg(struct virtio_driver* driver, uint8_t bar,
         }
     }
 
+
+    driver->internals.num_queues = le16_to_cpu(cfg->num_queues);
+
+    if (driver->max_queues) {
+#if DEBUG_LEVEL_TRACE
+        kprintf("virtio-pci: device %d limiting number of queues to %d (max supported by driver) from %d\n", driver->device, driver->max_queues, driver->internals.num_queues);
+#endif
+        if (driver->internals.num_queues > driver->max_queues)
+            driver->internals.num_queues = driver->max_queues;
+    }
+
     cfg_set_status_and_check(VIRTIO_DEVICE_STATUS_FEATURES_OK);
 
 
@@ -226,12 +233,9 @@ static int virtio_pci_init_common_cfg(struct virtio_driver* driver, uint8_t bar,
     //
     // Interrupts Handler
     //
-
-
 #if defined(CONFIG_HAVE_PCI_MSIX)
 
     pci_msix_t msix;
-
     if (pci_find_msix(driver->device, &msix) == PCI_NONE) {
 
     #if DEBUG_LEVEL_FATAL
@@ -241,66 +245,73 @@ static int virtio_pci_init_common_cfg(struct virtio_driver* driver, uint8_t bar,
         return cfg->device_status = VIRTIO_DEVICE_STATUS_FAILED, -ENOSYS;
     }
 
+    #if DEBUG_LEVEL_TRACE
+    kprintf("virtio-pci: device %d MSI-X capabilities found [caps(%p), rows(%p), vectors(%d)]\n", driver->device, msix.msix_cap, msix.msix_rows, msix.msix_pci.pci_msgctl_table_size + 1);
+    #endif
 
-    int i;
-    for (i = 0; i < cfg->num_queues; i++) {
+
+    // NOTE:
+    // Mapping MSI-X vectors:
+    //  vectors[0..(MSIX_VECTORS - 1)]  -> queues 0..num_queues
+    //  vectors[MSIX_VECTORS]           -> config interrupt
+    uint16_t vector_limit = msix.msix_pci.pci_msgctl_table_size + 1;
+
+    for (size_t k = 0; k < driver->internals.num_queues; k++) {
+
+        uint16_t i = k % (vector_limit - 1);
 
         pci_msix_map_irq(driver->device, &msix, (pci_irq_handler_t)virtio_pci_interrupt, (pci_irq_data_t)driver, i);
         pci_msix_unmask(driver->device, &msix, i);
     }
 
-    cfg->config_msix_vector = i;
+    pci_msix_map_irq(driver->device, &msix, (pci_irq_handler_t)virtio_pci_interrupt, (pci_irq_data_t)driver, vector_limit - 1);
+    pci_msix_unmask(driver->device, &msix, vector_limit - 1);
 
-    pci_msix_map_irq(driver->device, &msix, (pci_irq_handler_t)virtio_pci_interrupt, (pci_irq_data_t)driver, i);
-    pci_msix_unmask(driver->device, &msix, i);
-    pci_msix_enable(driver->device, &msix);
-
-
-    #if DEBUG_LEVEL_TRACE
-    kprintf("virtio-pci: device %d MSI-X capabilities found [caps(%p), rows(%p), count(%d), config_msix_vector(%p)]\n", driver->device, msix.msix_cap, msix.msix_rows, msix.msix_pci.pci_msgctl_table_size, cfg->config_msix_vector);
-    #endif
+    cfg->config_msix_vector = vector_limit - 1;
 
 #else
+
+#if DEBUG_LEVEL_TRACE
+    pci_msix_t msix;
+    if (pci_find_msix(driver->device, &msix) != PCI_NONE) {
+    #if DEBUG_LEVEL_WARN
+        kprintf("virtio-pci: WARN! device %d has MSI-X capabilities but the kernel was built without MSI-X support\n", driver->device);
+    #endif
+        DEBUG_ASSERT(pci_msix_is_enabled(driver->device, &msix) == false);
+    }
+#endif
 
     driver->internals.irq = pci_read(driver->device, PCI_INTERRUPT_LINE, 1);
 
     if (driver->internals.irq != PCI_INTERRUPT_LINE_NONE) {
-
         pci_intx_map_irq(driver->device, driver->internals.irq, (pci_irq_handler_t)virtio_pci_interrupt, (pci_irq_data_t)driver);
         pci_intx_unmask(driver->device);
     }
 
 #endif
 
-
-
     //
     // Queue
     //
-
-    for (size_t i = 0; i < cfg->num_queues; i++) {
+    for (size_t i = 0; i < driver->internals.num_queues; i++) {
 
         if (virtq_init(driver, cfg, i) < 0) {
-
 #if DEBUG_LEVEL_FATAL
             kprintf("virtio-pci: FAIL! device %d queue %d initialization failed\n", driver->device, i);
 #endif
-
             return cfg->device_status = VIRTIO_DEVICE_STATUS_FAILED, -ENOSYS;
         }
     }
 
-    driver->internals.num_queues = cfg->num_queues;
-
-
+#if defined(CONFIG_HAVE_PCI_MSIX)
+    pci_msix_enable(driver->device, &msix);
+#endif
 
     cfg_set_status_and_check(VIRTIO_DEVICE_STATUS_DRIVER_OK);
 
-
 #if DEBUG_LEVEL_TRACE
-    kprintf("virtio-pci: device %d common initialization successful\n", driver->device);
+    kprintf("virtio-pci: device %d common initialization successful [queues(%d)]\n", driver->device, driver->internals.num_queues);
 #endif
-
     return 0;
 }
 
@@ -313,25 +324,18 @@ static int virtio_pci_init_device_cfg(struct virtio_driver* driver, uintptr_t ca
     DEBUG_ASSERT(caps);
     DEBUG_ASSERT(bar >= 0 && bar <= 5);
 
-
     driver->internals.device_config = virtio_pci_find_bar(driver, bar, offset);
 
-
     int e = 0;
-
     if (unlikely(!driver->setup))
         return e;
 
     if ((e = driver->setup(driver, driver->internals.device_config)) < 0)
         return e;
 
-
-
 #if DEBUG_LEVEL_TRACE
     kprintf("virtio-pci: device %d obtaining device config successful [caps(%d), bar(%d), offset(%p)]\n", driver->device, caps, bar, offset);
 #endif
-
-
     return 0;
 }
 
@@ -344,14 +348,11 @@ static int virtio_pci_init_isr_status(struct virtio_driver* driver, uint8_t bar,
     DEBUG_ASSERT(offset);
     DEBUG_ASSERT(bar >= 0 && bar <= 5);
 
-
     driver->internals.isr_status = (uint32_t volatile*)virtio_pci_find_bar(driver, bar, offset);
-
 
 #if DEBUG_LEVEL_TRACE
     kprintf("virtio-pci: device %d obtaining isr status successful [bar(%d), offset(%d), isr(%p)]\n", driver->device, bar, offset, driver->internals.isr_status);
 #endif
-
     return 0;
 }
 
@@ -363,10 +364,8 @@ static int virtio_pci_init_notify_cfg(struct virtio_driver* driver, uintptr_t ca
     DEBUG_ASSERT(driver->device);
     DEBUG_ASSERT(caps);
 
-
     struct virtio_pci_notify_cfg cfg;
     pci_memcpy(driver->device, &cfg, caps + sizeof(struct virtio_pci_cap), sizeof(struct virtio_pci_notify_cfg));
-
 
     if (unlikely(cfg.notify_off_multiplier == 0)) {
 #if DEBUG_LEVEL_FATAL
@@ -375,15 +374,12 @@ static int virtio_pci_init_notify_cfg(struct virtio_driver* driver, uintptr_t ca
         return errno = EINVAL, -1;
     }
 
-
     driver->internals.notify_off_multiplier = le32_to_cpu(cfg.notify_off_multiplier);
     driver->internals.notify_offset         = virtio_pci_find_bar(driver, bar, offset);
-
 
 #if DEBUG_LEVEL_TRACE
     kprintf("virtio-pci: device %d obtaining notify_off_multiplier successful [caps(%d), multiplier(%d)]\n", driver->device, caps, driver->internals.notify_off_multiplier);
 #endif
-
     return 0;
 }
 
@@ -394,25 +390,19 @@ int virtio_pci_init(struct virtio_driver* driver) {
     DEBUG_ASSERT(driver);
     DEBUG_ASSERT(driver->device);
 
-
     uintptr_t caps;
     if ((caps = pci_find_capabilities(driver->device)) == PCI_NONE) {
-
 #if DEBUG_LEVEL_FATAL
         kprintf("virtio-pci: FAIL! cannot find capabilities for pci device %d\n", driver->device);
 #endif
-
         return errno = EINVAL, -1;
     }
-
 
     pci_enable_pio(driver->device);
     pci_enable_mmio(driver->device);
     pci_enable_bus_mastering(driver->device);
 
-
     struct virtio_pci_cap cap;
-
     do {
 
         pci_memcpy(driver->device, &cap, caps, sizeof(struct virtio_pci_cap));
@@ -424,50 +414,37 @@ int virtio_pci_init(struct virtio_driver* driver) {
         cap.offset = le32_to_cpu(cap.offset);
         cap.length = le32_to_cpu(cap.length);
 
-
         int e;
-
         switch (cap.cfg_type) {
 
             case VIRTIO_PCI_CAP_COMMON_CFG:
-
                 if ((e = virtio_pci_init_common_cfg(driver, cap.bar, cap.offset)) < 0)
                     return e;
 
                 break;
 
-
             case VIRTIO_PCI_CAP_DEVICE_CFG:
-
                 if ((e = virtio_pci_init_device_cfg(driver, caps, cap.bar, cap.offset)) < 0)
                     return e;
 
                 break;
 
-
             case VIRTIO_PCI_CAP_ISR_CFG:
-
                 if ((e = virtio_pci_init_isr_status(driver, cap.bar, cap.offset)) < 0)
                     return e;
 
                 break;
 
-
             case VIRTIO_PCI_CAP_NOTIFY_CFG:
-
                 if ((e = virtio_pci_init_notify_cfg(driver, caps, cap.bar, cap.offset)) < 0)
                     return e;
 
                 break;
 
-
             case VIRTIO_PCI_CAP_PCI_CFG:
-
                 break;
 
-
             default:
-
 #if DEBUG_LEVEL_WARN
                 kprintf("virtio-pci: WARN! found unknown configuration type %d [offset(%p)]\n", cap.cfg_type, caps);
 #endif
@@ -476,11 +453,9 @@ int virtio_pci_init(struct virtio_driver* driver) {
 
     } while ((caps = cap.cap_next) != 0);
 
-
 #if DEBUG_LEVEL_TRACE
     kprintf("virtio-pci: device %d pci initialization successful [irq(%d)]\n", driver->device, driver->internals.irq);
 #endif
-
 
     return 0;
 }

--- a/drivers/virtio/virtio-queue/main.c
+++ b/drivers/virtio/virtio-queue/main.c
@@ -248,7 +248,7 @@ int virtq_poll(struct virtio_driver* driver, uint16_t queue, uint16_t seen, uint
 
     } while (seen != 0xFFFF);
 
-    return 0xFFFF;
+    return -1;
 
 }
 

--- a/drivers/virtio/virtio-queue/main.c
+++ b/drivers/virtio/virtio-queue/main.c
@@ -48,52 +48,103 @@ MODULE_AUTHOR("Antonino Natale");
 MODULE_LICENSE("GPL");
 
 
-
-int virtq_init(struct virtio_driver* driver, struct virtio_pci_common_cfg volatile* cfg, uint16_t index) {
-
+static size_t virtq_get_total_size(struct virtio_driver* driver, struct virtio_pci_common_cfg volatile* cfg) {
     DEBUG_ASSERT(driver);
     DEBUG_ASSERT(cfg);
     DEBUG_ASSERT(cfg->queue_size);
 
+    size_t queue_size = cfg->queue_size;
+    size_t total_size = 0;
 
+    total_size += queue_size * 16; // Descriptors
+    total_size &= ~0xFFF;
+    total_size += 0x1000;
+
+    total_size += queue_size * 2 + 6; // Available ring
+    total_size &= ~0xFFF;
+    total_size += 0x1000;
+    
+    total_size += queue_size * 8 + 6; // Used ring
+    total_size &= ~0xFFF;
+    total_size += 0x1000;
+
+    total_size += queue_size * driver->send_window_size; // Send buffers
+    total_size &= ~0xFFF;
+    total_size += 0x1000;
+
+    total_size += queue_size * driver->recv_window_size; // Receive buffers
+    total_size &= ~0xFFF;
+    total_size += 0x1000;
+
+    return total_size;
+}
+
+
+int virtq_init(struct virtio_driver* driver, struct virtio_pci_common_cfg volatile* cfg, uint16_t index) {
+    DEBUG_ASSERT(driver);
+    DEBUG_ASSERT(cfg);
+    DEBUG_ASSERT(cfg->queue_size);
 
     mmio_w16(&cfg->queue_select, cpu_to_le16(index));
     atomic_thread_fence(memory_order_seq_cst);
 
 
-    size_t qsize = cfg->queue_size;
+    size_t phys_size = virtq_get_total_size(driver, cfg);
+    uintptr_t phys_buffer = pmm_alloc_blocks(phys_size / PML1_PAGESIZE + 1);
+    uintptr_t virt_buffer = arch_vmm_p2v(phys_buffer, ARCH_VMM_AREA_HEAP);
 
-
-    uintptr_t pbuf = pmm_alloc_blocks(((qsize * 16) + (qsize * 2 + 6) + (qsize * 8 + 6) + (qsize * driver->send_window_size) + (qsize * driver->recv_window_size)) / PML1_PAGESIZE + 1);
-
-    if (unlikely(!pbuf))
+    if (unlikely(!phys_buffer))
         return errno = ENOMEM, -1;
 
+    size_t q_size = le16_to_cpu(cfg->queue_size);
+    uintptr_t q_offset = 0;
 
-    void* qdesc = (void*)arch_vmm_p2v(pbuf + (0), ARCH_VMM_AREA_HEAP);
-    void* qfree = (void*)arch_vmm_p2v(pbuf + (qsize * 16), ARCH_VMM_AREA_HEAP);
-    void* qused = (void*)arch_vmm_p2v(pbuf + (qsize * 16) + (qsize * 2 + 6), ARCH_VMM_AREA_HEAP);
+    uintptr_t q_descriptors = virt_buffer + q_offset;
+    uintptr_t p_descriptors = phys_buffer + q_offset;
+    q_offset += (q_size * 16);
+    q_offset &= ~0xFFF;
+    q_offset += 0x1000;
 
-    if (!qdesc || !qfree || !qused)
-        return errno = EFAULT, -1;
+    uintptr_t q_available = virt_buffer + q_offset;
+    uintptr_t p_available = phys_buffer + q_offset;
+    q_offset += (q_size * 2 + 6);
+    q_offset &= ~0xFFF;
+    q_offset += 0x1000;
 
+    uintptr_t q_used = virt_buffer + q_offset;
+    uintptr_t p_used = phys_buffer + q_offset;
+    q_offset += (q_size * 8 + 6);
+    q_offset &= ~0xFFF;
+    q_offset += 0x1000;
 
-    memset(qdesc, 0, qsize * 16);
-    memset(qfree, 0, qsize * 2 + 6);
-    memset(qused, 0, qsize * 8 + 6);
+    uintptr_t q_sendbuf = virt_buffer + q_offset;
+    uintptr_t p_sendbuf = phys_buffer + q_offset;
+    q_offset += (q_size * driver->send_window_size);
+    q_offset &= ~0xFFF;
+    q_offset += 0x1000;
 
+    uintptr_t q_recvbuf = virt_buffer + q_offset;
+    uintptr_t p_recvbuf = phys_buffer + q_offset;
+    q_offset += (q_size * driver->recv_window_size);
+    q_offset &= ~0xFFF;
+    q_offset += 0x1000;
 
-    driver->internals.queues[index].buffers.sendbuf = pbuf + (qsize * 16) + (qsize * 2 + 6) + (qsize * 8 + 6);
-    driver->internals.queues[index].buffers.recvbuf = pbuf + (qsize * 16) + (qsize * 2 + 6) + (qsize * 8 + 6) + (qsize * driver->send_window_size);
+    memset((void*)q_descriptors, 0, q_size * 16);
+    memset((void*)q_available, 0, q_size * 2 + 6);
+    memset((void*)q_used, 0, q_size * 8 + 6);
+    memset((void*)q_sendbuf, 0, q_size * driver->send_window_size);
+    memset((void*)q_recvbuf, 0, q_size * driver->recv_window_size);
 
-    driver->internals.queues[index].descriptors = (struct virtq_descriptor volatile*)qdesc;
-    driver->internals.queues[index].available   = (struct virtq_available volatile*)qfree;
-    driver->internals.queues[index].used        = (struct virtq_used volatile*)qused;
-    driver->internals.queues[index].notify      = (struct virtq_notify volatile*)driver->internals.notify_offset + (cfg->queue_notify_off * driver->internals.notify_off_multiplier);
-    driver->internals.queues[index].size        = qsize;
+    driver->internals.queues[index].buffers.sendbuf = p_sendbuf;
+    driver->internals.queues[index].buffers.recvbuf = p_recvbuf;
 
+    driver->internals.queues[index].descriptors = (struct virtq_descriptor volatile*)q_descriptors;
+    driver->internals.queues[index].available   = (struct virtq_available volatile*)q_available;
+    driver->internals.queues[index].used        = (struct virtq_used volatile*)q_used;
+    driver->internals.queues[index].notify      = (struct virtq_notify volatile*)(driver->internals.notify_offset + (cfg->queue_notify_off * driver->internals.notify_off_multiplier));
+    driver->internals.queues[index].size        = q_size;
+    
     sem_init(&driver->internals.queues[index].iosem, 0);
-
 
 
 #if defined(CONFIG_HAVE_PCI_MSIX)
@@ -102,22 +153,18 @@ int virtq_init(struct virtio_driver* driver, struct virtio_pci_common_cfg volati
     cfg->queue_msix_vector = cpu_to_le16(VIRTIO_MSI_NO_VECTOR);
 #endif
 
-    cfg->queue_desc   = cpu_to_le64(pbuf + (0));
-    cfg->queue_driver = cpu_to_le64(pbuf + (qsize * 16));
-    cfg->queue_device = cpu_to_le64(pbuf + (qsize * 16) + (qsize * 2 + 6));
-    cfg->queue_enable = cpu_to_le16(1);
-
-    atomic_thread_fence(memory_order_release);
-
+    cfg->queue_desc   = cpu_to_le64(p_descriptors);
+    cfg->queue_driver = cpu_to_le64(p_available);
+    cfg->queue_device = cpu_to_le64(p_used);
+    cfg->queue_enable = cpu_to_le16(1);    
 
 #if DEBUG_LEVEL_TRACE
     kprintf("virtio-queue: driver %d initialized queue %d successful [desc(%p), device(%p), driver(%p), enable(%d), msix(%p), notify(%p), size(%d)]\n", driver->device, index, cfg->queue_desc, cfg->queue_device, cfg->queue_driver,
-            cfg->queue_enable, cfg->queue_msix_vector, cfg->queue_notify_off, cfg->queue_size);
+            cfg->queue_enable, cfg->queue_msix_vector, driver->internals.queues[index].notify, cfg->queue_size);
 #endif
 
     return 0;
 }
-
 
 
 int virtq_get_free_descriptor(struct virtio_driver* driver, uint16_t queue) {
@@ -130,28 +177,25 @@ int virtq_get_free_descriptor(struct virtio_driver* driver, uint16_t queue) {
 
     for (uint16_t d = 1; d < driver->internals.queues[queue].size; d++) {
 
-
         if (driver->internals.queues[queue].descriptors[d].q_address)
             continue;
 
-
         if (({ // Search in available buffers
-                int free = 1;
+                bool free = true;
 
                 for (uint16_t i = 0; i < driver->internals.queues[queue].size; i++) {
 
                     if (driver->internals.queues[queue].available->q_ring[i] != cpu_to_le16(d))
                         continue;
 
-                    free = 0;
+                    free = false;
                     break;
                 }
 
                 free;
 
-            }) == 0)
+            }) == false)
             continue;
-
 
         driver->internals.queues[queue].descriptors[d].q_address = 0xFFFFFFFFFFFFFFFF;
         driver->internals.queues[queue].descriptors[d].q_length  = 0;
@@ -166,7 +210,7 @@ int virtq_get_free_descriptor(struct virtio_driver* driver, uint16_t queue) {
 
 
 
-ssize_t virtq_sendrecv(struct virtio_driver* driver, uint16_t queue, void* message, size_t size, void* output, size_t outsize) {
+ssize_t virtq_sendrecv(struct virtio_driver* driver, uint16_t queue, const void* message, size_t size, void* output, size_t outsize) {
 
     DEBUG_ASSERT(driver);
     DEBUG_ASSERT(driver->device);
@@ -179,33 +223,21 @@ ssize_t virtq_sendrecv(struct virtio_driver* driver, uint16_t queue, void* messa
     DEBUG_ASSERT(size < driver->send_window_size);
     DEBUG_ASSERT(outsize < driver->recv_window_size);
 
-
-
     ssize_t inp = virtq_get_free_descriptor(driver, queue);
     ssize_t out = virtq_get_free_descriptor(driver, queue);
-
 
 #if DEBUG_LEVEL_TRACE
     kprintf("virtio-queue: device %d is sendrecv on queue %d [inp(%d), out(%d), message(%p), size(%p), output(%p), outsize(%p)]\n", driver->device, queue, inp, out, message, size, output, outsize);
 #endif
 
-
     if (unlikely(inp < 0 || out < 0)) {
-
 #if DEBUG_LEVEL_FATAL
         kprintf("virtio-queue: FAIL! device %d has no free descriptor in queue %d\n", driver->device, queue);
 #endif
-
         return errno = ENOSPC, -1;
     }
 
-
-
     memcpy((void*)arch_vmm_p2v(driver->internals.queues[queue].buffers.sendbuf + (inp * driver->send_window_size), ARCH_VMM_AREA_HEAP), message, size);
-
-
-
-    atomic_thread_fence(memory_order_acq_rel);
 
     driver->internals.queues[queue].descriptors[inp].q_address = cpu_to_le64(driver->internals.queues[queue].buffers.sendbuf + (inp * driver->send_window_size));
     driver->internals.queues[queue].descriptors[inp].q_length  = cpu_to_le32(size);
@@ -217,61 +249,129 @@ ssize_t virtq_sendrecv(struct virtio_driver* driver, uint16_t queue, void* messa
     driver->internals.queues[queue].descriptors[out].q_flags   = cpu_to_le16(VIRTQ_DESC_F_WRITE);
     driver->internals.queues[queue].descriptors[out].q_next    = cpu_to_le16(0);
 
-
-
-    atomic_thread_fence(memory_order_acq_rel);
-
     uint16_t seen = le16_to_cpu(driver->internals.queues[queue].used->q_idx);
     uint16_t next = le16_to_cpu(driver->internals.queues[queue].available->q_idx) % driver->internals.queues[queue].size;
 
     driver->internals.queues[queue].available->q_ring[next] = cpu_to_le16(inp);
     driver->internals.queues[queue].available->q_flags      = cpu_to_le16(0);
     driver->internals.queues[queue].available->q_idx        = cpu_to_le16(le16_to_cpu(driver->internals.queues[queue].available->q_idx) + 1);
-
-    atomic_thread_fence(memory_order_acq_rel);
-
+    
+    atomic_thread_fence(memory_order_release);
+    
     driver->internals.queues[queue].notify->n_idx = cpu_to_le16(queue);
-
-    atomic_thread_fence(memory_order_acq_rel);
-
 
 
     sem_wait(&driver->internals.queues[queue].iosem);
 
-
     do {
 
-        for (size_t i = seen; i < le16_to_cpu(driver->internals.queues[queue].used->q_idx); i++) {
+        for (size_t k = seen; k < le16_to_cpu(driver->internals.queues[queue].used->q_idx); k++) {
+
+            atomic_thread_fence(memory_order_acquire);
+
+            uint16_t i = k % driver->internals.queues[queue].size;
 
             if (le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_id) != inp)
                 continue;
 
+            if (le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length) < outsize) {
+                outsize = le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length);
+            }
 
             memcpy(output, (void*)arch_vmm_p2v(driver->internals.queues[queue].buffers.recvbuf + (out * driver->recv_window_size), ARCH_VMM_AREA_HEAP), outsize);
-
 
 #if DEBUG_LEVEL_TRACE
             kprintf("virtio-queue: device %d has received %d bytes from idx: %d\n", driver->device, le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length), i);
 #endif
-
             seen = 0xFFFF;
             break;
         }
 
-        atomic_thread_fence(memory_order_seq_cst);
-
     } while (seen != 0xFFFF);
-
 
 #if DEBUG_LEVEL_TRACE
     kprintf("virtio-queue: device %d has sent and received %ld bytes of data on queue %d\n", driver->device, outsize, queue);
 #endif
-
     return outsize;
 }
 
 
-ssize_t virtq_send(struct virtio_driver* driver, uint16_t queue, void* message, size_t size) {
+ssize_t virtq_recv(struct virtio_driver* driver, uint16_t queue, void* output, size_t outsize) {
+
+    DEBUG_ASSERT(driver);
+    DEBUG_ASSERT(driver->device);
+    DEBUG_ASSERT(output);
+    DEBUG_ASSERT(outsize);
+
+    DEBUG_ASSERT(queue < driver->internals.num_queues);
+    DEBUG_ASSERT(outsize < driver->recv_window_size);
+
+    ssize_t out = virtq_get_free_descriptor(driver, queue);
+
+#if DEBUG_LEVEL_TRACE
+    kprintf("virtio-queue: device %d is recv on queue %d [out(%d), output(%p), outsize(%p)]\n", driver->device, queue, out, output, outsize);
+#endif
+
+    if (unlikely(out < 0)) {
+#if DEBUG_LEVEL_FATAL
+        kprintf("virtio-queue: FAIL! device %d has no free descriptor in queue %d\n", driver->device, queue);
+#endif
+        return errno = ENOSPC, -1;
+    }
+
+    driver->internals.queues[queue].descriptors[out].q_address = cpu_to_le64(driver->internals.queues[queue].buffers.recvbuf + (out * driver->recv_window_size));
+    driver->internals.queues[queue].descriptors[out].q_length  = cpu_to_le32(outsize);
+    driver->internals.queues[queue].descriptors[out].q_flags   = cpu_to_le16(VIRTQ_DESC_F_WRITE);
+    driver->internals.queues[queue].descriptors[out].q_next    = cpu_to_le16(0);
+
+    uint16_t seen = le16_to_cpu(driver->internals.queues[queue].used->q_idx);
+    uint16_t next = le16_to_cpu(driver->internals.queues[queue].available->q_idx) % driver->internals.queues[queue].size;
+
+    driver->internals.queues[queue].available->q_ring[next] = cpu_to_le16(out);
+    driver->internals.queues[queue].available->q_flags      = cpu_to_le16(0);
+    driver->internals.queues[queue].available->q_idx        = cpu_to_le16(le16_to_cpu(driver->internals.queues[queue].available->q_idx) + 1);
+
+    atomic_thread_fence(memory_order_release);
+
+    *(volatile uint16_t*)driver->internals.queues[queue].notify = cpu_to_le16(queue);
+
+
+    sem_wait(&driver->internals.queues[queue].iosem);
+
+    do {
+
+        for (size_t k = seen; k < le16_to_cpu(driver->internals.queues[queue].used->q_idx); k++) {
+            
+            atomic_thread_fence(memory_order_acquire);
+
+            uint16_t i = k % driver->internals.queues[queue].size;
+
+            if (le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_id) != out)
+                continue;
+
+            if (le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length) < outsize) {
+                outsize = le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length);
+            }
+
+            memcpy(output, (void*)arch_vmm_p2v(driver->internals.queues[queue].buffers.recvbuf + (out * driver->recv_window_size), ARCH_VMM_AREA_HEAP), outsize);
+
+#if DEBUG_LEVEL_TRACE
+            kprintf("virtio-queue: device %d has received %d bytes from idx: %d\n", driver->device, le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length), i);
+#endif
+            seen = 0xFFFF;
+            break;
+        }
+
+    } while (seen != 0xFFFF);
+
+#if DEBUG_LEVEL_TRACE
+    kprintf("virtio-queue: device %d has received %ld bytes of data on queue %d\n", driver->device, outsize, queue);
+#endif
+    return outsize;
+}
+
+
+ssize_t virtq_send(struct virtio_driver* driver, uint16_t queue, const void* message, size_t size) {
 
     DEBUG_ASSERT(driver);
     DEBUG_ASSERT(driver->device);
@@ -281,40 +381,25 @@ ssize_t virtq_send(struct virtio_driver* driver, uint16_t queue, void* message, 
     DEBUG_ASSERT(queue < driver->internals.num_queues);
     DEBUG_ASSERT(size < driver->send_window_size);
 
-
-
     ssize_t inp = virtq_get_free_descriptor(driver, queue);
-
 
 #if DEBUG_LEVEL_TRACE
     kprintf("virtio-queue: device %d send on queue %d [inp(%d), message(%p), size(%p)]\n", driver->device, queue, inp, message, size);
 #endif
 
-
     if (unlikely(inp < 0)) {
-
 #if DEBUG_LEVEL_FATAL
         kprintf("virtio-queue: FAIL! device %d has no free descriptor in queue %d\n", driver->device, queue);
 #endif
-
         return errno = ENOSPC, -1;
     }
 
-
-
     memcpy((void*)arch_vmm_p2v(driver->internals.queues[queue].buffers.sendbuf + (inp * driver->send_window_size), ARCH_VMM_AREA_HEAP), message, size);
-
-
-
-    atomic_thread_fence(memory_order_acq_rel);
 
     driver->internals.queues[queue].descriptors[inp].q_address = cpu_to_le64(driver->internals.queues[queue].buffers.sendbuf + (inp * driver->send_window_size));
     driver->internals.queues[queue].descriptors[inp].q_length  = cpu_to_le32(size);
     driver->internals.queues[queue].descriptors[inp].q_flags   = cpu_to_le16(0);
     driver->internals.queues[queue].descriptors[inp].q_next    = cpu_to_le16(0);
-
-    atomic_thread_fence(memory_order_acq_rel);
-
 
     uint16_t next = le16_to_cpu(driver->internals.queues[queue].available->q_idx) % driver->internals.queues[queue].size;
 
@@ -322,23 +407,19 @@ ssize_t virtq_send(struct virtio_driver* driver, uint16_t queue, void* message, 
     driver->internals.queues[queue].available->q_flags      = cpu_to_le16(0);
     driver->internals.queues[queue].available->q_idx        = cpu_to_le16(le16_to_cpu(driver->internals.queues[queue].available->q_idx) + 1);
 
-
+    atomic_thread_fence(memory_order_release);
+    
     driver->internals.queues[queue].notify->n_idx = cpu_to_le16(queue);
-
-
-    atomic_thread_fence(memory_order_acq_rel);
-
 
     return size;
 }
 
 
-
 void virtq_flush(struct virtio_driver* driver, uint16_t queue) {
+    DEBUG_ASSERT(driver);
+    DEBUG_ASSERT(queue < driver->internals.num_queues);
     sem_post(&driver->internals.queues[queue].iosem);
 }
-
-
 
 void init(const char* args) {
 }

--- a/drivers/virtio/virtio-queue/main.c
+++ b/drivers/virtio/virtio-queue/main.c
@@ -145,7 +145,7 @@ int virtq_init(struct virtio_driver* driver, struct virtio_pci_common_cfg volati
     driver->internals.queues[index].size        = q_size;
     
     sem_init(&driver->internals.queues[index].iosem, 0);
-
+    spinlock_init_with_flags(&driver->internals.queues[index].lock, SPINLOCK_FLAGS_CPU_OWNER);
 
 #if defined(CONFIG_HAVE_PCI_MSIX)
     cfg->queue_msix_vector = cpu_to_le16(index);
@@ -167,48 +167,90 @@ int virtq_init(struct virtio_driver* driver, struct virtio_pci_common_cfg volati
 }
 
 
-int virtq_get_free_descriptor(struct virtio_driver* driver, uint16_t queue) {
+uint16_t virtq_alloc_descriptor(struct virtio_driver* driver, uint16_t queue) {
 
     DEBUG_ASSERT(driver);
     DEBUG_ASSERT(driver->device);
 
     DEBUG_ASSERT(queue < driver->internals.num_queues);
 
+    scoped_lock(&driver->internals.queues[queue].lock) {
 
-    for (uint16_t d = 1; d < driver->internals.queues[queue].size; d++) {
+        for (uint16_t d = 1; d < driver->internals.queues[queue].size; d++) {
 
-        if (driver->internals.queues[queue].descriptors[d].q_address)
-            continue;
+            if (driver->internals.queues[queue].descriptors[d].q_address)
+                continue;
 
-        if (({ // Search in available buffers
-                bool free = true;
+            driver->internals.queues[queue].descriptors[d].q_address = 0xFFFFFFFFFFFFFFFF;
+            driver->internals.queues[queue].descriptors[d].q_length  = 0;
+            driver->internals.queues[queue].descriptors[d].q_flags   = 0;
+            driver->internals.queues[queue].descriptors[d].q_next    = 0;
 
-                for (uint16_t i = 0; i < driver->internals.queues[queue].size; i++) {
+            kprintf("virtio-queue: device %d allocated descriptor %d on queue %d\n", driver->device, d, queue);
 
-                    if (driver->internals.queues[queue].available->q_ring[i] != cpu_to_le16(d))
-                        continue;
+            return d;
+        }
 
-                    free = false;
-                    break;
-                }
-
-                free;
-
-            }) == false)
-            continue;
-
-        driver->internals.queues[queue].descriptors[d].q_address = 0xFFFFFFFFFFFFFFFF;
-        driver->internals.queues[queue].descriptors[d].q_length  = 0;
-        driver->internals.queues[queue].descriptors[d].q_flags   = 0;
-        driver->internals.queues[queue].descriptors[d].q_next    = 0;
-
-        return d;
     }
 
-    return -1;
+    return 0;
 }
 
+void virtq_free_descriptor(struct virtio_driver* driver, uint16_t queue, uint16_t desc) {
 
+    DEBUG_ASSERT(driver);
+    DEBUG_ASSERT(driver->device);
+
+    DEBUG_ASSERT(queue < driver->internals.num_queues);
+    DEBUG_ASSERT(desc < driver->internals.queues[queue].size);
+
+    scoped_lock(&driver->internals.queues[queue].lock) {
+        driver->internals.queues[queue].descriptors[desc].q_address = 0;
+        driver->internals.queues[queue].descriptors[desc].q_length  = 0;
+        driver->internals.queues[queue].descriptors[desc].q_flags   = 0;
+        driver->internals.queues[queue].descriptors[desc].q_next    = 0;
+    }
+
+}
+
+int virtq_poll(struct virtio_driver* driver, uint16_t queue, uint16_t seen, uint16_t descriptor, size_t* outsize) {
+    DEBUG_ASSERT(driver);
+    
+    do {
+
+        for (size_t k = seen; k < le16_to_cpu(driver->internals.queues[queue].used->q_idx); k++) {
+
+            atomic_thread_fence(memory_order_acquire);
+
+            uint16_t i = k % driver->internals.queues[queue].size;
+
+            if (le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_id) != descriptor)
+                continue;
+
+            if (outsize) {
+                size_t requested_size = *outsize;
+                size_t received_size = le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length);
+
+                if (requested_size > received_size) {
+                    requested_size = received_size;
+                }
+
+                *outsize = requested_size;
+            }
+
+#if DEBUG_LEVEL_TRACE
+            kprintf("virtio-queue: device %d has received %d bytes from idx: %d\n", driver->device, le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length), i);
+#endif
+            
+            return i;
+
+        }
+
+    } while (seen != 0xFFFF);
+
+    return 0xFFFF;
+
+}
 
 ssize_t virtq_sendrecv(struct virtio_driver* driver, uint16_t queue, const void* message, size_t size, void* output, size_t outsize) {
 
@@ -223,8 +265,8 @@ ssize_t virtq_sendrecv(struct virtio_driver* driver, uint16_t queue, const void*
     DEBUG_ASSERT(size < driver->send_window_size);
     DEBUG_ASSERT(outsize < driver->recv_window_size);
 
-    ssize_t inp = virtq_get_free_descriptor(driver, queue);
-    ssize_t out = virtq_get_free_descriptor(driver, queue);
+    ssize_t inp = virtq_alloc_descriptor(driver, queue);
+    ssize_t out = virtq_alloc_descriptor(driver, queue);
 
 #if DEBUG_LEVEL_TRACE
     kprintf("virtio-queue: device %d is sendrecv on queue %d [inp(%d), out(%d), message(%p), size(%p), output(%p), outsize(%p)]\n", driver->device, queue, inp, out, message, size, output, outsize);
@@ -260,34 +302,16 @@ ssize_t virtq_sendrecv(struct virtio_driver* driver, uint16_t queue, const void*
     
     driver->internals.queues[queue].notify->n_idx = cpu_to_le16(queue);
 
-
-    sem_wait(&driver->internals.queues[queue].iosem);
-
-    do {
-
-        for (size_t k = seen; k < le16_to_cpu(driver->internals.queues[queue].used->q_idx); k++) {
-
-            atomic_thread_fence(memory_order_acquire);
-
-            uint16_t i = k % driver->internals.queues[queue].size;
-
-            if (le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_id) != inp)
-                continue;
-
-            if (le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length) < outsize) {
-                outsize = le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length);
-            }
-
-            memcpy(output, (void*)arch_vmm_p2v(driver->internals.queues[queue].buffers.recvbuf + (out * driver->recv_window_size), ARCH_VMM_AREA_HEAP), outsize);
-
-#if DEBUG_LEVEL_TRACE
-            kprintf("virtio-queue: device %d has received %d bytes from idx: %d\n", driver->device, le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length), i);
-#endif
-            seen = 0xFFFF;
-            break;
-        }
-
-    } while (seen != 0xFFFF);
+    int e = virtq_poll(driver, queue, seen, out, &outsize);
+    
+    virtq_free_descriptor(driver, queue, inp);
+    virtq_free_descriptor(driver, queue, out);
+    
+    if (e < 0) {
+        return errno = EIO, -1;
+    } else {
+        memcpy(output, (void*)arch_vmm_p2v(driver->internals.queues[queue].buffers.recvbuf + (out * driver->recv_window_size), ARCH_VMM_AREA_HEAP), outsize);
+    }
 
 #if DEBUG_LEVEL_TRACE
     kprintf("virtio-queue: device %d has sent and received %ld bytes of data on queue %d\n", driver->device, outsize, queue);
@@ -306,7 +330,7 @@ ssize_t virtq_recv(struct virtio_driver* driver, uint16_t queue, void* output, s
     DEBUG_ASSERT(queue < driver->internals.num_queues);
     DEBUG_ASSERT(outsize < driver->recv_window_size);
 
-    ssize_t out = virtq_get_free_descriptor(driver, queue);
+    ssize_t out = virtq_alloc_descriptor(driver, queue);
 
 #if DEBUG_LEVEL_TRACE
     kprintf("virtio-queue: device %d is recv on queue %d [out(%d), output(%p), outsize(%p)]\n", driver->device, queue, out, output, outsize);
@@ -335,34 +359,15 @@ ssize_t virtq_recv(struct virtio_driver* driver, uint16_t queue, void* output, s
 
     *(volatile uint16_t*)driver->internals.queues[queue].notify = cpu_to_le16(queue);
 
-
-    sem_wait(&driver->internals.queues[queue].iosem);
-
-    do {
-
-        for (size_t k = seen; k < le16_to_cpu(driver->internals.queues[queue].used->q_idx); k++) {
-            
-            atomic_thread_fence(memory_order_acquire);
-
-            uint16_t i = k % driver->internals.queues[queue].size;
-
-            if (le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_id) != out)
-                continue;
-
-            if (le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length) < outsize) {
-                outsize = le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length);
-            }
-
-            memcpy(output, (void*)arch_vmm_p2v(driver->internals.queues[queue].buffers.recvbuf + (out * driver->recv_window_size), ARCH_VMM_AREA_HEAP), outsize);
-
-#if DEBUG_LEVEL_TRACE
-            kprintf("virtio-queue: device %d has received %d bytes from idx: %d\n", driver->device, le32_to_cpu(driver->internals.queues[queue].used->q_elements[i].e_length), i);
-#endif
-            seen = 0xFFFF;
-            break;
-        }
-
-    } while (seen != 0xFFFF);
+    int e = virtq_poll(driver, queue, seen, out, &outsize);
+    
+    virtq_free_descriptor(driver, queue, out);
+    
+    if (e < 0) {
+        return errno = EIO, -1;
+    } else {
+        memcpy(output, (void*)arch_vmm_p2v(driver->internals.queues[queue].buffers.recvbuf + (out * driver->recv_window_size), ARCH_VMM_AREA_HEAP), outsize);
+    }
 
 #if DEBUG_LEVEL_TRACE
     kprintf("virtio-queue: device %d has received %ld bytes of data on queue %d\n", driver->device, outsize, queue);
@@ -381,7 +386,7 @@ ssize_t virtq_send(struct virtio_driver* driver, uint16_t queue, const void* mes
     DEBUG_ASSERT(queue < driver->internals.num_queues);
     DEBUG_ASSERT(size < driver->send_window_size);
 
-    ssize_t inp = virtq_get_free_descriptor(driver, queue);
+    ssize_t inp = virtq_alloc_descriptor(driver, queue);
 
 #if DEBUG_LEVEL_TRACE
     kprintf("virtio-queue: device %d send on queue %d [inp(%d), message(%p), size(%p)]\n", driver->device, queue, inp, message, size);

--- a/drivers/virtio/virtio-random/Makefile
+++ b/drivers/virtio/virtio-random/Makefile
@@ -1,0 +1,13 @@
+
+SRCDIRS	 := .
+INCLUDES := $(ROOTDIR)/include
+DEFINES	 := KERNEL=1 MODULE=1
+LIBS	 := 
+
+CFLAGS   := -include $(ROOTDIR)/config.h
+ASFLAGS  := -include $(ROOTDIR)/config.h
+
+
+include $(ROOTDIR)/drivers/platform/$(PLATFORM)/config.mk
+include $(ROOTDIR)/build/cross.mk
+include $(ROOTDIR)/build/build-ko.mk

--- a/drivers/virtio/virtio-random/main.c
+++ b/drivers/virtio/virtio-random/main.c
@@ -1,0 +1,174 @@
+/*
+ * Author:
+ *      Antonino Natale <antonio.natale97@hotmail.com>
+ *
+ * Copyright (c) 2013-2019 Antonino Natale
+ *
+ *
+ * This file is part of aplus.
+ *
+ * aplus is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * aplus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with aplus.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include <aplus.h>
+#include <aplus/debug.h>
+#include <aplus/errno.h>
+#include <aplus/fb.h>
+#include <aplus/hal.h>
+#include <aplus/memory.h>
+#include <aplus/module.h>
+#include <aplus/smp.h>
+
+#include <dev/char.h>
+#include <dev/interface.h>
+#include <dev/pci.h>
+
+#include <dev/virtio/virtio-random.h>
+#include <dev/virtio/virtio.h>
+
+
+MODULE_NAME("virtio/virtio-random");
+MODULE_DEPS("dev/interface,dev/pci,virtio/virtio-pci,virtio/virtio-queue");
+MODULE_AUTHOR("Antonino Natale");
+MODULE_LICENSE("GPL");
+
+
+
+static void virtrandom_init(device_t*);
+static void virtrandom_dnit(device_t*);
+static void virtrandom_reset(device_t*);
+static ssize_t virtrandom_write(device_t*, const void*, size_t);
+static ssize_t virtrandom_read(device_t*, void*, size_t);
+
+
+device_t device = {
+
+    .type = DEVICE_TYPE_CHAR,
+
+    .name        = "hwrng",
+    .description = "VIRTIO Random Device",
+
+    .major = 10,
+    .minor = 183,
+
+    .status = DEVICE_STATUS_UNKNOWN,
+
+    .init  = virtrandom_init,
+    .dnit  = virtrandom_dnit,
+    .reset = virtrandom_reset,
+
+    .chr.io = CHAR_IO_NBF,
+    .chr.write = virtrandom_write,
+    .chr.read  = virtrandom_read,
+
+};
+
+
+static int negotiate_features(struct virtio_driver* driver, uint32_t* features, size_t index) {
+    return 0;
+}
+
+static int setup_config(struct virtio_driver* driver, uintptr_t device_config) {
+    return 0;
+}
+
+static void pci_find(pcidev_t device, uint16_t vid, uint16_t did, void* arg) {
+
+    device_t* config = (device_t*)arg;
+
+    if (config->userdata != NULL)
+        return;
+
+    if (vid != VIRTIO_PCI_VENDOR)
+        return;
+
+    if (did != VIRTIO_PCI_DEVICE(VIRTIO_DEVICE_TYPE_ENTROPY_SOURCE))
+        return;
+
+
+    struct virtio_driver* driver = kcalloc(1, sizeof(struct virtio_driver), GFP_KERNEL);
+
+    driver->type             = VIRTIO_DEVICE_TYPE_ENTROPY_SOURCE;
+    driver->device           = device;
+    driver->send_window_size = 4096;
+    driver->recv_window_size = 8192;
+    driver->max_queues       = 0;
+
+    driver->negotiate = &negotiate_features;
+    driver->setup     = &setup_config;
+    driver->interrupt = NULL;
+
+
+    if (virtio_pci_init(driver) < 0) {
+#if DEBUG_LEVEL_ERROR
+        kprintf("virtio-random: device %d (%X:%X) initialization failed\n", device, vid, did);
+#endif
+        return;
+    }
+
+    config->userdata = driver;
+}
+
+
+static void virtrandom_init(device_t* device) {
+    DEBUG_ASSERT(device);
+    virtrandom_reset(device);
+}
+
+static void virtrandom_dnit(device_t* device) {
+    DEBUG_ASSERT(device);
+}
+
+static void virtrandom_reset(device_t* device) {
+    DEBUG_ASSERT(device);
+}
+
+static ssize_t virtrandom_write(device_t* device, const void* buf, size_t size) {
+    DEBUG_ASSERT(device);
+    DEBUG_ASSERT(device->userdata);
+    DEBUG_ASSERT(buf);
+
+    errno = ENOSPC;
+    return -1;
+}
+
+static ssize_t virtrandom_read(device_t* device, void* buf, size_t size) {
+    DEBUG_ASSERT(device);
+    DEBUG_ASSERT(device->userdata);
+    DEBUG_ASSERT(buf);
+
+    if (unlikely(size == 0))
+        return 0;
+
+    return virtq_recv((struct virtio_driver*)device->userdata, VIRTIO_RANDOM_QUEUE_DATA, buf, size);
+}
+
+void init(const char* args) {
+
+    if (strstr(core->boot.cmdline, "virtio=off"))
+        return;
+
+    pci_scan(&pci_find, PCI_TYPE_ALL, &device);
+
+    if (device.userdata == NULL)
+        return;
+
+    device_mkdev(&device, 0644);
+}
+
+void dnit(void) {
+}

--- a/include/aplus/hal.h
+++ b/include/aplus/hal.h
@@ -71,6 +71,10 @@
     #define ARCH_TASK_CONTEXT_PARAM4 8
     #define ARCH_TASK_CONTEXT_PARAM5 9
 
+    #define ARCH_INTR_TYPE_DEFAULT 0
+    #define ARCH_INTR_TYPE_PCI     1
+    #define ARCH_INTR_TYPE_MSI     2
+
 
     #ifndef R_OK
         #define R_OK 4
@@ -143,10 +147,8 @@ void arch_debug_stacktrace(uintptr_t*, size_t);
 
 void arch_intr_enable(long);
 long arch_intr_disable(void);
-void arch_intr_map_irq(irq_t, void (*)(void*, irq_t));
-void arch_intr_unmap_irq(irq_t);
-void arch_intr_map_irq_without_ioapic(irq_t, void (*)(void*, irq_t));
-void arch_intr_unmap_irq_without_ioapic(irq_t);
+void arch_intr_map_irq(irq_t, void (*)(void*, irq_t), int);
+void arch_intr_unmap_irq(irq_t, int);
 
 
 void arch_task_switch(task_t*, task_t*);

--- a/include/aplus/vfs.h
+++ b/include/aplus/vfs.h
@@ -148,8 +148,8 @@ struct file {
     inode_t* inode;
     off_t position;
 
-    int status;
-    int refcount;
+    atomic_int status;
+    atomic_int refcount;
 
     spinlock_t lock;
 };

--- a/include/arch/x86/apic.h
+++ b/include/arch/x86/apic.h
@@ -95,6 +95,12 @@
     #define X86_IOAPIC_IOAPICREDTBL(n) (0x10 + 2 * n)
     #define X86_IOAPIC_MAX             0x10
 
+    #define X86_IOAPIC_REDTTBL_FLAG_MASK                    0x0000FFFFFFFFFF00ULL
+    #define X86_IOAPIC_REDTTBL_FLAG_TRIGGER_MODE_LEVEL      (1 << 15)
+    #define X86_IOAPIC_REDTTBL_FLAG_TRIGGER_MODE_EDGE       (0 << 15)
+    #define X86_IOAPIC_REDTTBL_FLAG_POLARITY_ACTIVE_LOW     (1 << 13)
+    #define X86_IOAPIC_REDTTBL_FLAG_POLARITY_ACTIVE_HIGH    (0 << 13)
+
 
 typedef struct {
     uintptr_t address;
@@ -115,7 +121,7 @@ void apic_timer_reset(uint32_t);
 
 
 void ioapic_enable(void);
-void ioapic_map_irq(irq_t, irq_t, cpuid_t);
+void ioapic_map_irq(irq_t, irq_t, cpuid_t, uint64_t);
 void ioapic_unmap_irq(irq_t);
 
 __END_DECLS

--- a/include/dev/pci.h
+++ b/include/dev/pci.h
@@ -39,6 +39,7 @@
 typedef uint32_t pcidev_t;
 
 
+    #define PCI_DEVICES_MAX     128
 
     #define PCI_VENDOR_ID   0x00
     #define PCI_DEVICE_ID   0x02
@@ -112,11 +113,34 @@ typedef uint32_t pcidev_t;
     #define PCI_STATUS_REG_INTERRUPT    (1 << 3)
     #define PCI_STATUS_REG_CAPABILITIES (1 << 4)
 
+
+    #define PCI_MSI_CAPID        (0x05)
+    
+    #define PCI_MSI_HDR_CAPID    (0)
+    #define PCI_MSI_HDR_CAPNEXT  (1)
+    #define PCI_MSI_HDR_MSGCTL   (2)
+    #define PCI_MSI_HDR_MSGADDR  (4)
+
+    #define PCI_MSI_MSGCTL_ENABLE               (1 << 0)
+    #define PCI_MSI_MSGCTL_ADDR_64BIT           (1 << 7)
+    #define PCI_MSI_MSGCTL_MSG_COUNT_MASK       (0x0070)
+
+    #define PCI_MSI_INTR_BASE   66
+    
+
     #define PCI_MSIX_CAPID     (0x11)
-    #define PCI_MSIX_ENABLE    (1 << 15)
-    #define PCI_MSIX_INTR_MASK (1 << 0)
 
+    #define PCI_MSIX_HDR_CAPID        (0)
+    #define PCI_MSIX_HDR_CAPNEXT      (1)
+    #define PCI_MSIX_HDR_MSGCTL       (2)
+    #define PCI_MSIX_HDR_TABLE        (4)
+    #define PCI_MSIX_HDR_PBA          (8)
 
+    #define PCI_MSIX_MSGCTL_ENABLE         (1 << 15)
+    #define PCI_MSIX_MSGCTL_MASK           (1 << 14)
+    #define PCI_MSIX_INTR_MASK             (1 << 0)
+
+    #define PCI_MSIX_INTR_BASE   66
 
     #define pci_extract_bus(x)  ((uint8_t)(x >> 16))
     #define pci_extract_slot(x) ((uint8_t)(x >> 8))
@@ -139,13 +163,50 @@ __BEGIN_DECLS
 
 
 
-typedef struct pci_msix_row {
+typedef struct pci_msi_row {
 
-    volatile uint64_t pr_address;
+    struct {
+        uint8_t pci_capid;
+        uint8_t pci_capnext;
+
+        union {
+            struct {
+                uint16_t pci_msgctl_enabled               : 1;
+                uint16_t pci_msgctl_multiple_msg_capable  : 3;
+                uint16_t pci_msgctl_multiple_msg_enable   : 3;
+                uint16_t pci_msgctl_64bit_address         : 1;
+                uint16_t pci_msgctl_reserved              : 8;
+            };
+            uint16_t pci_msgctl;
+        };
+
+    } msi_header;
+
+    struct {
+        union {
+            uint64_t pci_msgaddr64;
+            uint32_t pci_msgaddr32;
+        };
+
+        uint16_t pci_msgdata;
+    } msi_data;
+
+} __packed pci_msi_row_t;
+
+typedef struct pci_msi {
+    uintptr_t msi_cap;
+} __packed pci_msi_t;
+
+typedef struct pci_msix_row {
+    volatile uint32_t pr_address;
+    volatile uint32_t pr_address64;
     volatile uint32_t pr_data;
     volatile uint32_t pr_ctl;
-
 } __packed pci_msix_row_t;
+
+typedef struct pci_msix_pba {
+    volatile uint32_t pb_bitmap[1];
+} __packed pci_msix_pba_t;
 
 typedef struct pci_msix {
 
@@ -178,13 +239,14 @@ typedef struct pci_msix {
 
     uintptr_t msix_cap;
     pci_msix_row_t volatile* msix_rows;
+    pci_msix_pba_t volatile* msix_pba;
 
 } __packed pci_msix_t;
 
 
 
 typedef void* pci_irq_data_t;
-typedef void (*pci_irq_handler_t)(pcidev_t, irq_t, pci_irq_data_t);
+typedef void (*pci_irq_handler_t)(pcidev_t, irq_t, pci_irq_data_t, uint16_t);
 
 
 
@@ -203,10 +265,19 @@ uintptr_t pci_find_capabilities(pcidev_t);
 uintptr_t pci_bar_size(pcidev_t, int, size_t);
 void pci_memcpy(pcidev_t, void*, uintptr_t, size_t);
 
+/* MSI */
+int pci_find_msi(pcidev_t, pci_msi_t*);
+void pci_msi_enable(pcidev_t, pci_msi_t*);
+void pci_msi_disable(pcidev_t, pci_msi_t*);
+bool pci_msi_is_enabled(pcidev_t, pci_msi_t*);
+int pci_msi_map_irq(pcidev_t, pci_msi_t*, pci_irq_handler_t, pci_irq_data_t);
+int pci_msi_unmap_irq(pcidev_t, pci_msi_t*);
+
 /* MSI-X */
 int pci_find_msix(pcidev_t, pci_msix_t*);
 void pci_msix_enable(pcidev_t, pci_msix_t*);
 void pci_msix_disable(pcidev_t, pci_msix_t*);
+bool pci_msix_is_enabled(pcidev_t, pci_msix_t*);
 void pci_msix_mask(pcidev_t, pci_msix_t*, uint32_t);
 void pci_msix_unmask(pcidev_t, pci_msix_t*, uint32_t);
 int pci_msix_map_irq(pcidev_t, pci_msix_t*, pci_irq_handler_t, pci_irq_data_t, uint16_t);
@@ -217,6 +288,12 @@ int pci_intx_map_irq(pcidev_t, irq_t, pci_irq_handler_t, pci_irq_data_t);
 int pci_intx_unmap_irq(pcidev_t);
 void pci_intx_mask(pcidev_t);
 void pci_intx_unmask(pcidev_t);
+
+/* Devices */
+uint16_t pci_dev_register(pcidev_t, pci_irq_handler_t, pci_irq_data_t, uint16_t);
+uint16_t pci_dev_unregister(pcidev_t);
+pcidev_t pci_dev_get_device(uint16_t);
+int pci_dev_call_handler(uint16_t index, irq_t irq);
 
 __END_DECLS
 

--- a/include/dev/virtio/virtio-random.h
+++ b/include/dev/virtio/virtio-random.h
@@ -1,0 +1,40 @@
+/*
+ * Author:
+ *      Antonino Natale <antonio.natale97@hotmail.com>
+ *
+ * Copyright (c) 2013-2019 Antonino Natale
+ *
+ *
+ * This file is part of aplus.
+ *
+ * aplus is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * aplus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with aplus.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _DEV_VIRTIO_VIRTIO_RANDOM_H
+#define _DEV_VIRTIO_VIRTIO_RANDOM_H
+
+#define VIRTIO_RANDOM_QUEUE_DATA 0
+
+#ifndef __ASSEMBLY__
+    #include <aplus.h>
+    #include <aplus/debug.h>
+    #include <aplus/syscall.h>
+    #include <stdint.h>
+
+__BEGIN_DECLS
+__END_DECLS
+
+#endif
+
+#endif

--- a/include/dev/virtio/virtio.h
+++ b/include/dev/virtio/virtio.h
@@ -119,6 +119,8 @@ struct virtio_driver {
     size_t send_window_size;
     size_t recv_window_size;
 
+    size_t max_queues;
+
     int (*negotiate)(struct virtio_driver*, uint32_t*, size_t);
     int (*setup)(struct virtio_driver*, uintptr_t);
     int (*interrupt)(pcidev_t, irq_t, struct virtio_driver*);
@@ -245,8 +247,8 @@ int virtio_pci_init(struct virtio_driver*);
 
 // Queue
 int virtq_init(struct virtio_driver*, struct virtio_pci_common_cfg volatile*, uint16_t);
-ssize_t virtq_send(struct virtio_driver*, uint16_t, void*, size_t);
-ssize_t virtq_sendrecv(struct virtio_driver*, uint16_t, void*, size_t, void*, size_t);
+ssize_t virtq_send(struct virtio_driver*, uint16_t, const void*, size_t);
+ssize_t virtq_sendrecv(struct virtio_driver*, uint16_t, const void*, size_t, void*, size_t);
 ssize_t virtq_recv(struct virtio_driver*, uint16_t, void*, size_t);
 void virtq_flush(struct virtio_driver*, uint16_t);
 

--- a/include/dev/virtio/virtio.h
+++ b/include/dev/virtio/virtio.h
@@ -140,6 +140,7 @@ struct virtio_driver {
 
         struct {
 
+            spinlock_t lock;
             semaphore_t iosem;
 
             struct virtq_descriptor volatile* descriptors;

--- a/kernel/fs/bindfs.c
+++ b/kernel/fs/bindfs.c
@@ -68,7 +68,7 @@ bind_fn(getattr, int, (inode_t * inode, struct stat* st), (d, st)) bind_fn(setat
     (void)args;
 
 
-    dir->sb         = (struct superblock*)kcalloc(sizeof(struct superblock), 1, GFP_KERNEL);
+    dir->sb         = (struct superblock*)kcalloc(1, sizeof(struct superblock), GFP_KERNEL);
     dir->sb->fsid   = 1;
     dir->sb->dev    = dev;
     dir->sb->root   = dir;

--- a/kernel/fs/ext2/ext2_cache.c
+++ b/kernel/fs/ext2/ext2_cache.c
@@ -38,7 +38,7 @@
 
 struct ext2_inode* ext2_icache_fetch(cache_t* cache, ext2_t* ext2, ino_t ino) {
 
-    struct ext2_inode* i = (struct ext2_inode*)kcalloc(sizeof(struct ext2_inode), 1, GFP_KERNEL);
+    struct ext2_inode* i = (struct ext2_inode*)kcalloc(1, sizeof(struct ext2_inode), GFP_KERNEL);
 
     if (unlikely(!i))
         return NULL;

--- a/kernel/fs/ext2/ext2_finddir.c
+++ b/kernel/fs/ext2/ext2_finddir.c
@@ -84,7 +84,7 @@ inode_t* ext2_finddir(inode_t* inode, const char* name) {
                 if (name_len == e->name_len && strncmp(name, e->name, e->name_len) == 0) {
 
 
-                    d = (inode_t*)kcalloc(sizeof(inode_t), 1, GFP_KERNEL);
+                    d = (inode_t*)kcalloc(1, sizeof(inode_t), GFP_KERNEL);
 
                     d->ino    = e->inode;
                     d->sb     = inode->sb;

--- a/kernel/fs/ext2/ext2_mount.c
+++ b/kernel/fs/ext2/ext2_mount.c
@@ -123,7 +123,7 @@ int ext2_mount(inode_t* dev, inode_t* dir, int flags, const char* args) {
 
 
 
-    dir->sb = (struct superblock*)kcalloc(sizeof(struct superblock), 1, GFP_KERNEL);
+    dir->sb = (struct superblock*)kcalloc(1, sizeof(struct superblock), GFP_KERNEL);
 
     dir->sb->fsid  = FSID_EXT2;
     dir->sb->dev   = dev;

--- a/kernel/fs/fd.c
+++ b/kernel/fs/fd.c
@@ -43,7 +43,7 @@ static unsigned int lowestfree = 0;
 
 void fd_init(void) {
 
-    filetable  = (struct file*)kcalloc(sizeof(struct file), CONFIG_FILE_MAX, GFP_KERNEL);
+    filetable  = (struct file*)kcalloc(CONFIG_FILE_MAX, sizeof(struct file), GFP_KERNEL);
     lowestfree = 0;
 
     spinlock_init(&filetable_lock);
@@ -67,7 +67,7 @@ struct file* fd_append(inode_t* inode, off_t position, int status) {
 
             lowestfree = i + 1;
 
-            filetable[i].refcount = 1;
+            atomic_store(&filetable[i].refcount, 1);
             filetable[i].inode    = inode;
             filetable[i].position = position;
             filetable[i].status   = status;
@@ -104,7 +104,7 @@ void fd_remove(struct file* fd, bool close) {
             fd->status   = 0;
 
 
-            unsigned int i = (int)((uintptr_t)fd - (uintptr_t)filetable) / sizeof(struct file);
+            int i = (int)(fd - filetable);
 
             DEBUG_ASSERT(i <= CONFIG_FILE_MAX - 1);
             DEBUG_ASSERT(i >= 0);

--- a/kernel/fs/fd.c
+++ b/kernel/fs/fd.c
@@ -68,6 +68,11 @@ struct file* fd_append(inode_t* inode, off_t position, int status) {
             lowestfree = i + 1;
 
             filetable[i].refcount = 1;
+            filetable[i].inode    = inode;
+            filetable[i].position = position;
+            filetable[i].status   = status;
+
+            spinlock_init(&filetable[i].lock);
             break;
         }
     }
@@ -76,15 +81,6 @@ struct file* fd_append(inode_t* inode, off_t position, int status) {
     if (i == CONFIG_FILE_MAX) {
         return errno = ENFILE, NULL;
     }
-
-
-
-    filetable[i].inode    = inode;
-    filetable[i].position = position;
-    filetable[i].status   = status;
-
-    spinlock_init(&filetable[i].lock);
-
 
     return &filetable[i];
 }
@@ -127,6 +123,6 @@ void fd_ref(struct file* file) {
     DEBUG_ASSERT(filetable);
 
     scoped_lock(&filetable_lock) {
-        atomic_fetch_sub(&file->refcount, 1);
+        atomic_fetch_add(&file->refcount, 1);
     }
 }

--- a/kernel/fs/iso9660/iso9660_finddir.c
+++ b/kernel/fs/iso9660/iso9660_finddir.c
@@ -92,7 +92,7 @@ inode_t* iso9660_finddir(inode_t* inode, const char* name) {
             if (unlikely(strncmp(child->name, name, ISO9660_MAX_NAME) == 0)) {
 
 
-                inode_t* d = (inode_t*)kcalloc(sizeof(inode_t), 1, GFP_KERNEL);
+                inode_t* d = (inode_t*)kcalloc(1, sizeof(inode_t), GFP_KERNEL);
 
                 d->ino    = child->st.st_ino;
                 d->sb     = inode->sb;

--- a/kernel/fs/iso9660/iso9660_mount.c
+++ b/kernel/fs/iso9660/iso9660_mount.c
@@ -66,7 +66,7 @@ int iso9660_mount(inode_t* dev, inode_t* dir, int flags, const char* args) {
 #undef __
 
 
-    iso9660_t* iso9660 = (iso9660_t*)kcalloc(sizeof(iso9660_t), 1, GFP_USER);
+    iso9660_t* iso9660 = (iso9660_t*)kcalloc(1, sizeof(iso9660_t), GFP_USER);
 
     iso9660->dev = dev;
     iso9660->dir = dir;
@@ -183,7 +183,7 @@ int iso9660_mount(inode_t* dev, inode_t* dir, int flags, const char* args) {
     DEBUG_ASSERT(iso9660->block_size == ISO9660_BLOCK_SIZE);
 
 
-    dir->sb = (struct superblock*)kcalloc(sizeof(struct superblock), 1, GFP_KERNEL);
+    dir->sb = (struct superblock*)kcalloc(1, sizeof(struct superblock), GFP_KERNEL);
 
     dir->sb->fsid   = FSID_ISO9660;
     dir->sb->dev    = dev;

--- a/kernel/fs/pipefs.c
+++ b/kernel/fs/pipefs.c
@@ -140,7 +140,7 @@ inode_t* vfs_mkfifo(inode_t* inode, size_t bufsize, int flags) {
     __unused_param(flags);
 
 
-    ringbuffer_t* rb = kcalloc(sizeof(ringbuffer_t), 1, GFP_KERNEL);
+    ringbuffer_t* rb = kcalloc(1, sizeof(ringbuffer_t), GFP_KERNEL);
 
     if (unlikely(!rb))
         return errno = ENOMEM, NULL;
@@ -163,7 +163,7 @@ inode_t* vfs_mkfifo(inode_t* inode, size_t bufsize, int flags) {
 
 inode_t* pipefs_inode() {
 
-    inode_t* inode = kcalloc(sizeof(inode_t), 1, GFP_KERNEL);
+    inode_t* inode = kcalloc(1, sizeof(inode_t), GFP_KERNEL);
 
     if (unlikely(!inode))
         return errno = ENOMEM, NULL;

--- a/kernel/fs/procfs/procfs_mount.c
+++ b/kernel/fs/procfs/procfs_mount.c
@@ -64,7 +64,7 @@ int procfs_mount(inode_t* dev, inode_t* dir, int flags, const char* args) {
 #undef __
 
 
-    dir->sb = (struct superblock*)kcalloc(sizeof(struct superblock), 1, GFP_KERNEL);
+    dir->sb = (struct superblock*)kcalloc(1, sizeof(struct superblock), GFP_KERNEL);
 
     dir->sb->fsid  = FSID_PROCFS;
     dir->sb->dev   = dev;

--- a/kernel/fs/procfs/procfs_service.c
+++ b/kernel/fs/procfs/procfs_service.c
@@ -144,7 +144,7 @@ inode_t* procfs_service_inode(inode_t* parent, char* name, mode_t mode, int (*fe
     DEBUG_ASSERT(name);
 
 
-    inode_t* inode = kcalloc(sizeof(inode_t), 1, GFP_KERNEL);
+    inode_t* inode = kcalloc(1, sizeof(inode_t), GFP_KERNEL);
 
     inode->ino    = __next_proc_ino++;
     inode->parent = parent;
@@ -154,7 +154,7 @@ inode_t* procfs_service_inode(inode_t* parent, char* name, mode_t mode, int (*fe
     strncpy(inode->name, name, CONFIG_MAXNAMLEN);
 
 
-    procfs_service_t* service = kcalloc(sizeof(procfs_service_t), 1, GFP_KERNEL);
+    procfs_service_t* service = kcalloc(1, sizeof(procfs_service_t), GFP_KERNEL);
 
     service->fetch = fetch;
     service->arg   = arg;

--- a/kernel/fs/tmpfs/tmpfs_cache.c
+++ b/kernel/fs/tmpfs/tmpfs_cache.c
@@ -42,7 +42,7 @@ tmpfs_inode_t* tmpfs_cache_fetch(cache_t* cache, tmpfs_t* tmpfs, ino_t ino) {
     DEBUG_ASSERT(tmpfs);
     DEBUG_ASSERT(cache);
 
-    tmpfs_inode_t* i = (tmpfs_inode_t*)kcalloc(sizeof(tmpfs_inode_t), 1, GFP_KERNEL);
+    tmpfs_inode_t* i = (tmpfs_inode_t*)kcalloc(1, sizeof(tmpfs_inode_t), GFP_KERNEL);
 
     i->capacity = 0;
     i->data     = NULL;

--- a/kernel/fs/tmpfs/tmpfs_creat.c
+++ b/kernel/fs/tmpfs/tmpfs_creat.c
@@ -58,7 +58,7 @@ inode_t* tmpfs_creat(inode_t* inode, const char* name, mode_t mode) {
     shared_ptr_access(current_task->fs, fs, { i->st.st_mode = mode & ~fs->umask; });
 
 
-    inode_t* d = (inode_t*)kcalloc(sizeof(inode_t), 1, GFP_KERNEL);
+    inode_t* d = (inode_t*)kcalloc(1, sizeof(inode_t), GFP_KERNEL);
 
     strncpy(d->name, name, CONFIG_MAXNAMLEN);
 

--- a/kernel/fs/tmpfs/tmpfs_mount.c
+++ b/kernel/fs/tmpfs/tmpfs_mount.c
@@ -67,7 +67,7 @@ int tmpfs_mount(inode_t* dev, inode_t* dir, int flags, const char* args) {
 
 
 
-    dir->sb = (struct superblock*)kcalloc(sizeof(struct superblock), 1, GFP_KERNEL);
+    dir->sb = (struct superblock*)kcalloc(1, sizeof(struct superblock), GFP_KERNEL);
 
     dir->sb->fsid  = FSID_TMPFS;
     dir->sb->dev   = dev;

--- a/kernel/mm/pmm.c
+++ b/kernel/mm/pmm.c
@@ -36,25 +36,25 @@
  * @brief pml2_bitmap[].
  *        Physical Page Map Level 2.
  */
-static uintptr_t pml2_bitmap[PML2_MAX_ENTRIES];
+static uintptr_t pml2_bitmap[PML2_MAX_ENTRIES] = { 0 };
 
 /*!
  * @brief pml2_pusage[].
  *        Number of allocated pages in Page Map Level 1.
  */
-static uint16_t pml2_pusage[PML2_MAX_ENTRIES];
+static uint16_t pml2_pusage[PML2_MAX_ENTRIES] = { 0 };
 
 /*!
  * @brief pml2_lock[].
  *        Array of spinlock for each page map.
  */
-static spinlock_t pml2_lock[PML2_MAX_ENTRIES];
+static spinlock_t pml2_lock[PML2_MAX_ENTRIES] = { 0 };
 
 /*!
  * @brief pml1_first_bitmap[].
  *        First preallocated Page Map Bitmap (0-2GiB)
  */
-static uint64_t pml1_first_preallocated_bitmaps[PML1_MAX_ENTRIES * PML1_PREALLOCATED_BITMAPS];
+static uint64_t pml1_first_preallocated_bitmaps[PML1_MAX_ENTRIES * PML1_PREALLOCATED_BITMAPS] = { 0 };
 
 /*!
  * @brief pmm_max_memory.

--- a/kernel/network/sys/mbox.c
+++ b/kernel/network/sys/mbox.c
@@ -83,7 +83,7 @@ err_t sys_mbox_new(struct sys_mbox** mbox, int size) {
     LWIP_UNUSED_ARG(size);
 
 
-    struct sys_mbox* m = (struct sys_mbox*)kcalloc(sizeof(struct sys_mbox), 1, GFP_KERNEL);
+    struct sys_mbox* m = (struct sys_mbox*)kcalloc(1, sizeof(struct sys_mbox), GFP_KERNEL);
 
     if (unlikely(!m)) {
         return ERR_MEM;

--- a/kernel/network/sys/sem.c
+++ b/kernel/network/sys/sem.c
@@ -81,7 +81,7 @@ err_t sys_sem_new(struct sys_sem** sem, u8_t count) {
     DEBUG_ASSERT(sem);
 
 
-    *(sem) = (struct sys_sem*)kcalloc(sizeof(struct sys_sem), 1, GFP_KERNEL);
+    *(sem) = (struct sys_sem*)kcalloc(1, sizeof(struct sys_sem), GFP_KERNEL);
 
     if (unlikely(*(sem) == NULL)) {
         return ERR_MEM;

--- a/kernel/syscalls/109_setpgid.c
+++ b/kernel/syscalls/109_setpgid.c
@@ -50,12 +50,78 @@
 
 SYSCALL(
     109, setpgid, long sys_setpgid(pid_t pid, pid_t pgid) {
-        DEBUG_ASSERT(pid == 0);
-        DEBUG_ASSERT(pgid == 0);
 
-        if (unlikely(pid != 0 || pgid != 0))
-            return -ENOSYS;
+        task_t* target = NULL;
 
-        current_task->pgrp = current_task->pid;
+        if(likely(pid == 0)) {
+            target = current_task;
+        } else {
+            cpu_foreach(cpu) {
+
+                task_t* tmp;
+                for (tmp = cpu->sched_queue; tmp; tmp = tmp->next) {
+                    if (tmp->tid == pid) {
+                        target = tmp;
+                        break;
+                    }
+                }
+
+                if (target)
+                    break;
+            }
+        }
+
+        if (unlikely(!target))
+            return -ESRCH;
+
+        // caller may change only itself or its children
+        if (unlikely(target != current_task && target->parent != current_task))
+            return -ESRCH;
+
+        // calling process and target must be in the same session
+        if (unlikely(target->sid != current_task->sid))
+            return -EPERM;
+
+        // target must not be a session leader
+        if (unlikely(target->tid == target->sid))
+            return -EPERM;
+
+        // pgid must be >= 0
+        if (unlikely(pgid < 0))
+            return -EINVAL;
+
+        // if pgid is 0, set it to target's pid
+        // else, check that pgid belongs to the same session
+        if (pgid == 0) {
+            pgid = target->tid;
+        } else if(pgid != target->tid) {
+            task_t* pgid_task = NULL;
+
+            cpu_foreach(cpu) {
+
+                task_t* tmp;
+                for (tmp = cpu->sched_queue; tmp; tmp = tmp->next) {
+                    if (tmp->tid == pgid) {
+                        pgid_task = tmp;
+                        break;
+                    }
+                }
+
+                if (pgid_task)
+                    break;
+            }
+
+            if (unlikely(!pgid_task))
+                return -EPERM;
+
+            if (unlikely(pgid_task->sid != target->sid))
+                return -EPERM;
+
+        }
+
+        scoped_lock(&target->lock) {
+            target->pgrp = pgid;
+        }
+
         return 0;
     });

--- a/kernel/syscalls/121_getpgid.c
+++ b/kernel/syscalls/121_getpgid.c
@@ -51,10 +51,8 @@ SYSCALL(
     121, getpgid, long sys_getpgid(pid_t pid) {
         DEBUG_ASSERT(current_task);
 
-
         if (pid == 0)
             return current_task->pgrp;
-
 
         cpu_foreach(cpu) {
 
@@ -65,7 +63,6 @@ SYSCALL(
                     return tmp->pgrp;
             }
         }
-
 
         return -ESRCH;
     });

--- a/kernel/syscalls/257_openat.c
+++ b/kernel/syscalls/257_openat.c
@@ -61,10 +61,7 @@ SYSCALL(
         if (unlikely(!uio_check(filename, R_OK)))
             return -EFAULT;
 
-
-
         inode_t* cwd = NULL;
-
 
         if (dfd < 0) {
 
@@ -95,12 +92,8 @@ SYSCALL(
 
         DEBUG_ASSERT(cwd);
 
-
-
         char __safe_filename[CONFIG_PATH_MAX] = {0};
         uio_strncpy_u2s(__safe_filename, filename, CONFIG_PATH_MAX);
-
-
 
 #if DEBUG_LEVEL_TRACE
         kprintf("openat(%d, \"%s\", %d, %d)\n", dfd, __safe_filename, flags, mode);
@@ -112,10 +105,7 @@ SYSCALL(
         if ((r = path_lookup(cwd, __safe_filename, flags, mode)) == NULL)
             return -errno;
 
-
-
         struct stat st = {0};
-
         if (vfs_getattr(r, &st) < 0) {
             return (errno == ENOSYS) ? -EACCES : -errno;
         }
@@ -140,7 +130,6 @@ SYSCALL(
 #endif
 
 
-
         if (current_task->uid != 0) {
 
             if (st.st_uid == current_task->uid) {
@@ -156,7 +145,6 @@ SYSCALL(
                     return -EACCES;
             }
         }
-
 
 
         inode_t* inode = NULL;
@@ -176,10 +164,11 @@ SYSCALL(
 
         shared_ptr_access(current_task->fd, fds, {
             scoped_lock(&current_task->lock) {
-                for (fd = 0; fd < CONFIG_OPEN_MAX; fd++) {
 
-                    if (fds->descriptors[fd].ref == NULL)
+                for (fd = 0; fd < CONFIG_OPEN_MAX; fd++) {
+                    if (fds->descriptors[fd].ref == NULL) {
                         break;
+                    }
                 }
 
                 if (fd == CONFIG_OPEN_MAX)

--- a/libk/utils/list.c
+++ b/libk/utils/list.c
@@ -63,7 +63,7 @@ size_t _list_length(list_head* list) {
 
 void _list_push(list_head** p_list, size_t value_size, void* value) {
     if (!*p_list)
-        *p_list = (list_head*)kcalloc(sizeof(list_head), 1, GFP_KERNEL);
+        *p_list = (list_head*)kcalloc(1, sizeof(list_head), GFP_KERNEL);
 
     list_head* list = *p_list;
 
@@ -87,7 +87,7 @@ void _list_push(list_head** p_list, size_t value_size, void* value) {
 
 void _list_push_front(list_head** p_list, size_t value_size, void* value) {
     if (!*p_list)
-        *p_list = (list_head*)kcalloc(sizeof(list_head), 1, GFP_KERNEL);
+        *p_list = (list_head*)kcalloc(1, sizeof(list_head), GFP_KERNEL);
 
     list_head* list = *p_list;
 

--- a/scripts/gen-image
+++ b/scripts/gen-image
@@ -204,7 +204,6 @@ else
 fi
 
 # Compress boot files
-
 for ko in $(find $TMPDIR/p1/usr/lib/modules -name "*.ko"); do
     compress $ko
 done


### PR DESCRIPTION
- **fix: correct file descriptor initialization and reference counting**
- **fix: correct kcalloc parameters and update refcount handling in file operations**
- **fix: correct kcalloc parameters for memory allocation across multiple files**
- **fix: implement process group ID management in setpgid syscall**
- **fix: replace int with atomic_int for status and refcount in file struct**
- **fix: adjust PCI value port calculations for 2-byte and 1-byte writes in pci_write and pci_read functions**
- **fix: replace arch_intr_unmap_irq with pci_intx_unmap_irq in AHCI de-initialization**
- **fix: enhance interrupt mapping by adding type parameter for arch_intr_map_irq and arch_intr_unmap_irq**
- **fix: update pci_intx_interrupt_handler to use size_t for loop index and add type parameter to arch_intr_map_irq**
- **fix: refactor PCI interrupt handling by consolidating device management and improving IRQ mapping**
- **fix: update virtio-console device initialization and improve read/write handling**
- **feat: add virtio-random driver implementation and header file**
- **feat: add max_queues field to virtio_driver and update virtq_send functions to use const void* for data**
- **fix: refactor virtq_init and add virtq_recv for improved queue management and memory handling**
- **feat: add MSI and MSIX support with new structures and functions for improved interrupt handling**
- **fix: initialize static arrays in pmm.c to prevent undefined behavior**
- **chore: remove unnecessary blank line before boot file compression loop**
- **fix: initialize display_info struct and use kcalloc for virtio_driver allocation**
- **fix: enhance virtq descriptor management with scoped locks and improved allocation logic**
- **fix: add spinlock to virtio_driver for improved concurrency control**
